### PR TITLE
Adding language selector for podcasts

### DIFF
--- a/includes/customize-feed.php
+++ b/includes/customize-feed.php
@@ -69,7 +69,7 @@ function bloginfo_rss_lang( $output, $requested ) {
 	if ( ! $term ) {
 		return $output;
 	}
-	// Ch
+
 	if ( 'language' === $requested ) {
 		$lang = get_term_meta( $term->term_id, 'podcasting_language', true );
 		if ( $lang ) {

--- a/includes/customize-feed.php
+++ b/includes/customize-feed.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * Customize the feed for a specific podcast. Insert the podcast data stored in term meta.
+ *
+ * @package tenup_podcasting
  */
+
 namespace tenup_podcasting;
 
 /**
@@ -266,8 +269,6 @@ add_filter( 'rss_enclosure', __NAMESPACE__ . '\rss_enclosure' );
 
 /**
  * Generate the category elements from the given option (e.g. podcasting_category_1).
- *
- * @param  string $option option to retrieve via get_term_meta
  */
 function generate_categories() {
 	$term = get_the_term();
@@ -283,7 +284,7 @@ function generate_categories() {
 
 	$reduced_categories = array();
 
-	foreach( $categories as $category ) {
+	foreach ( $categories as $category ) {
 		$category = explode( ':', $category );
 
 		if ( ! isset( $reduced_categories[ $category[0] ] ) ) {
@@ -297,7 +298,7 @@ function generate_categories() {
 
 	$categories = get_podcasting_categories();
 
-	foreach( $reduced_categories as $parent => $subs ) {
+	foreach ( $reduced_categories as $parent => $subs ) {
 		if ( ! isset( $categories[ $parent ] ) ) {
 			continue;
 		}
@@ -307,7 +308,7 @@ function generate_categories() {
 		} else {
 			echo '<itunes:category text="' . esc_html( $categories[ $parent ]['name'] ) . "\">\n";
 
-			foreach( $subs as $sub ) {
+			foreach ( $subs as $sub ) {
 				if ( ! isset( $categories[ $parent ]['subcategories'][ $sub ] ) ) {
 					continue;
 				}

--- a/includes/customize-feed.php
+++ b/includes/customize-feed.php
@@ -52,6 +52,31 @@ add_filter( 'wp_title_rss', __NAMESPACE__ . '\bloginfo_rss_name' );
 // Don't show audio widgets in the feed.
 add_filter( 'wp_audio_shortcode', '__return_empty_string', 999 );
 
+
+/**
+ * Sets the podcast language in the feed to the one selected in the term edit screen.
+ *
+ * @param string $output    The value being displayed
+ * @param string $requested The item that was requested
+ *
+ * @return mixed
+ */
+function bloginfo_rss_lang( $output, $requested ) {
+	$term = get_the_term();
+	if ( ! $term ) {
+		return $output;
+	}
+	// Ch
+	if ( 'language' === $requested ) {
+		$lang = get_term_meta( $term->term_id, 'podcasting_language', true );
+		if ( $lang ) {
+			$output = $lang;
+		}
+	}
+	return $output;
+}
+add_filter( 'bloginfo_rss', __NAMESPACE__ . '\bloginfo_rss_lang', 10, 2 );
+
 /**
  * Add podcasting details to the feed header.
  */

--- a/includes/datatypes.php
+++ b/includes/datatypes.php
@@ -160,6 +160,9 @@ function add_podcasting_term_add_meta_fields( $term ) {
  */
 function the_field( $field, $value = '', $term_id = false ) {
 	switch ( $field['type'] ) {
+		case 'language':
+			echo $field['data'];
+		break;
 		case 'textfield':
 		?>
 			<input
@@ -408,6 +411,12 @@ function get_meta_fields() {
 			),
 		),
 		array(
+			'slug'  => 'podcasting_language',
+			'title' => __( 'Language', 'simple-podcasting' ),
+			'type'  => 'language',
+			'data'  => get_podcasting_language_options(),
+		),
+		array(
 			'slug'        => 'podcasting_image',
 			'title'       => __( 'Podcast image', 'simple-podcasting' ),
 			'type'        => 'image',
@@ -590,4 +599,30 @@ function get_podcasting_categories_options() {
 	}
 
 	return $to_return;
+}
+
+/**
+ * Return the list of available languages.
+ *
+ * @see wp_dropdown_languages()
+ *
+ * @return string
+ */
+function get_podcasting_language_options() {
+	$lang = '';
+	if ( is_admin() ) {
+		global $tag_ID;
+		// Are we on the term edit screen?
+		$term_id = $tag_ID;
+		if ( $term_id ) {
+			$lang = get_term_meta( $term_id, 'podcasting_language', true );
+		}
+	}
+	return \wp_dropdown_languages(
+		array(
+			'echo'     => false,
+			'name'     => 'podcasting_language',
+			'selected' => $lang,
+		)
+	);
 }

--- a/includes/datatypes.php
+++ b/includes/datatypes.php
@@ -1,42 +1,75 @@
 <?php
+/**
+ * Register the data types
+ *
+ * @package tenup_podcasting
+ */
+
 namespace tenup_podcasting;
 
+/**
+ * Register the post meta to be associated with podcasts.
+ */
 function register_meta() {
-	\register_meta( 'post', 'podcast_url', array(
-		'show_in_rest' => true,
-		'type'         => 'string',
-		'single'       => true,
-	) );
+	\register_meta(
+		'post',
+		'podcast_url',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'string',
+			'single'       => true,
+		)
+	);
 
-	\register_meta( 'post', 'podcast_explicit', array(
-		'show_in_rest' => true,
-		'type'         => 'string',
-		'single'       => true,
-	) );
+	\register_meta(
+		'post',
+		'podcast_explicit',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'string',
+			'single'       => true,
+		)
+	);
 
-	\register_meta( 'post', 'podcast_captioned', array(
-		'show_in_rest' => true,
-		'type'         => 'boolean',
-		'single'       => true,
-	) );
+	\register_meta(
+		'post',
+		'podcast_captioned',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'boolean',
+			'single'       => true,
+		)
+	);
 
-	\register_meta( 'post', 'podcast_duration', array(
-		'show_in_rest' => true,
-		'type'         => 'string',
-		'single'       => true,
-	) );
+	\register_meta(
+		'post',
+		'podcast_duration',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'string',
+			'single'       => true,
+		)
+	);
 
-	\register_meta( 'post', 'podcast_filesize', array(
-		'show_in_rest' => true,
-		'type'         => 'number',
-		'single'       => true,
-	) );
+	\register_meta(
+		'post',
+		'podcast_filesize',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'number',
+			'single'       => true,
+		)
+	);
 
-	\register_meta( 'post', 'podcast_mime', array(
-		'show_in_rest' => true,
-		'type'         => 'string',
-		'single'       => true,
-	) );
+	\register_meta(
+		'post',
+		'podcast_mime',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'string',
+			'single'       => true,
+		)
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_meta' );
 
@@ -44,39 +77,47 @@ add_action( 'init', __NAMESPACE__ . '\register_meta' );
  * Add a custom podcasts taxonomy.
  */
 function create_podcasts_taxonomy() {
-	register_taxonomy( TAXONOMY_NAME, 'post', array(
-		'labels'            => array(
-			'name'                  => __( 'Podcasts', 'simple-podcasting' ),
-			'singular_name'         => __( 'Podcast', 'simple-podcasting' ),
-			'search_items'          => __( 'Search Podcasts', 'simple-podcasting' ),
-			'all_items'             => __( 'All Podcasts', 'simple-podcasting' ),
-			'parent_item'           => __( 'Parent Podcast', 'simple-podcasting' ),
-			'parent_item_colon'     => __( 'Parent Podcast:', 'simple-podcasting' ),
-			'edit_item'             => __( 'Edit Podcast', 'simple-podcasting' ),
-			'view_item'             => __( 'View Podcast', 'simple-podcasting' ),
-			'update_item'           => __( 'Update Podcast', 'simple-podcasting' ),
-			'add_new_item'          => __( 'Add New Podcast', 'simple-podcasting' ),
-			'new_item_name'         => __( 'New Podcast Name', 'simple-podcasting' ),
-			'add_or_remove_items'   => __( 'Add or remove podcasts', 'simple-podcasting' ),
-			'not_found'             => __( 'No podcasts found', 'simple-podcasting' ),
-			'no_terms'              => __( 'No podcasts', 'simple-podcasting' ),
-			'items_list_navigation' => __( 'Podcasts list navigation', 'simple-podcasting' ),
-			'items_list'            => __( 'Podcasts list', 'simple-podcasting' ),
-			'back_to_items'         => __( '&larr; Back to Podcasts', 'simple-podcasting' ),
-		),
-		'hierarchical'      => true,
-		'show_tagcloud'     => false,
-		'public'            => true,
-		'show_in_rest'      => true,
-		'show_in_nav_menus' => false,
-		'show_admin_column' => true,
-		'rewrite'           => array( 'slug' => 'podcasts' ),
-	) );
+	register_taxonomy(
+		TAXONOMY_NAME,
+		'post',
+		array(
+			'labels'            => array(
+				'name'                  => __( 'Podcasts', 'simple-podcasting' ),
+				'singular_name'         => __( 'Podcast', 'simple-podcasting' ),
+				'search_items'          => __( 'Search Podcasts', 'simple-podcasting' ),
+				'all_items'             => __( 'All Podcasts', 'simple-podcasting' ),
+				'parent_item'           => __( 'Parent Podcast', 'simple-podcasting' ),
+				'parent_item_colon'     => __( 'Parent Podcast:', 'simple-podcasting' ),
+				'edit_item'             => __( 'Edit Podcast', 'simple-podcasting' ),
+				'view_item'             => __( 'View Podcast', 'simple-podcasting' ),
+				'update_item'           => __( 'Update Podcast', 'simple-podcasting' ),
+				'add_new_item'          => __( 'Add New Podcast', 'simple-podcasting' ),
+				'new_item_name'         => __( 'New Podcast Name', 'simple-podcasting' ),
+				'add_or_remove_items'   => __( 'Add or remove podcasts', 'simple-podcasting' ),
+				'not_found'             => __( 'No podcasts found', 'simple-podcasting' ),
+				'no_terms'              => __( 'No podcasts', 'simple-podcasting' ),
+				'items_list_navigation' => __( 'Podcasts list navigation', 'simple-podcasting' ),
+				'items_list'            => __( 'Podcasts list', 'simple-podcasting' ),
+				'back_to_items'         => __( '&larr; Back to Podcasts', 'simple-podcasting' ),
+			),
+			'hierarchical'      => true,
+			'show_tagcloud'     => false,
+			'public'            => true,
+			'show_in_rest'      => true,
+			'show_in_nav_menus' => false,
+			'show_admin_column' => true,
+			'rewrite'           => array( 'slug' => 'podcasts' ),
+		)
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\create_podcasts_taxonomy' );
 
 /**
  * Filter the menu so podcasts are parent-less.
+ *
+ * @param string $file Url to the parent page.
+ *
+ * @return string
  */
 function filter_parent_file( $file ) {
 	$screen = get_current_screen();
@@ -98,13 +139,17 @@ function register_term_meta() {
 	$podcasting_meta_fields = get_meta_fields();
 
 	foreach ( $podcasting_meta_fields as $field ) {
-		register_meta( 'term', $field['slug'], array(
-			'sanitize_callback' => 'sanitize_my_meta_key',
-			'type'              => $field['type'],
-			'description'       => $field['title'],
-			'single'            => true,
-			'show_in_rest'      => false,
-		) );
+		register_meta(
+			'term',
+			$field['slug'],
+			array(
+				'sanitize_callback' => 'sanitize_my_meta_key',
+				'type'              => $field['type'],
+				'description'       => $field['title'],
+				'single'            => true,
+				'show_in_rest'      => false,
+			)
+		);
 	}
 }
 add_action( 'init', __NAMESPACE__ . '\register_term_meta' );
@@ -138,6 +183,8 @@ add_action( 'after-podcasting_podcasts-table', __NAMESPACE__ . '\add_podcasting_
 
 /**
  * Add fields to the add term screen.
+ *
+ * @param \WP_Term $term The term object.
  */
 function add_podcasting_term_add_meta_fields( $term ) {
 	$podcasting_meta_fields = get_meta_fields();
@@ -181,7 +228,7 @@ function the_field( $field, $value = '', $term_id = false ) {
 			);
 			break;
 		case 'textfield':
-		?>
+			?>
 			<input
 				name="<?php echo esc_attr( $field['slug'] ); ?>"
 				id="<?php echo esc_attr( $field['slug'] ); ?>"
@@ -189,21 +236,21 @@ function the_field( $field, $value = '', $term_id = false ) {
 				value="<?php echo esc_attr( $value ); ?>"
 				size="40"
 			>
-		<?php
+			<?php
 			break;
 		case 'textarea':
-		?>
+			?>
 			<textarea name="<?php echo esc_attr( $field['slug'] ); ?>" id="<?php echo esc_attr( $field['slug'] ); ?>" rows="5" cols="40"><?php echo esc_textarea( $value ); ?></textarea>
-		<?php
+			<?php
 			break;
 		case 'select':
-		?>
+			?>
 			<select
 				name="<?php echo esc_attr( $field['slug'] ); ?>"
 				id="<?php echo esc_attr( $field['slug'] ); ?>"
 				class="postform"
 			>
-		<?php
+			<?php
 			$options = $field['options'];
 			foreach ( $options as $key => $label ) {
 				?>
@@ -212,13 +259,13 @@ function the_field( $field, $value = '', $term_id = false ) {
 				</option>
 				<?php
 			}
-		?>
+			?>
 			</select>
-		<?php
+			<?php
 			break;
 		case 'image':
 			$image_url = get_term_meta( $term_id, $field['slug'] . '_url', true );
-		?>
+			?>
 			<div class="media-wrapper">
 				<?php
 				$has_image = ( '' === $value );
@@ -256,19 +303,21 @@ function the_field( $field, $value = '', $term_id = false ) {
 					>
 				</div>
 			</div>
-		<?php
+			<?php
 			break;
 
 	}
 	if ( isset( $field['description'] ) ) {
-	?>
+		?>
 		<p class="description"><?php echo esc_html( $field['description'] ); ?></p>
-	<?php
+		<?php
 	}
 }
 
 /**
  * Save podcasting fields from the term screen to term meta.
+ *
+ * @param int $term_id The term is being saved.
  */
 function save_podcasting_term_meta( $term_id ) {
 	$tax = get_taxonomy( TAXONOMY_NAME );
@@ -302,6 +351,8 @@ add_action( 'created_' . TAXONOMY_NAME, __NAMESPACE__ . '\save_podcasting_term_m
 
 /**
  * Add podcasting fields to the term screen.
+ *
+ * @param \WP_Term $term The term object.
  */
 function add_podcasting_term_edit_meta_fields( $term ) {
 	$podcasting_meta_fields = get_meta_fields();
@@ -334,6 +385,9 @@ function add_podcasting_term_edit_meta_fields( $term ) {
 
 /**
  * Add podcasting nonce to the term screen.
+ *
+ * @param \WP_Term $term     The term object.
+ * @param bool     $taxonomy Is this a taxonomy.
  */
 function add_podcasting_term_meta_nonce( $term, $taxonomy = false ) {
 	echo '<style>
@@ -364,6 +418,8 @@ add_action( TAXONOMY_NAME . '_add_form_fields', __NAMESPACE__ . '\add_podcasting
  * @param string $string      Blank string.
  * @param string $column_name Name of the column.
  * @param int    $term_id     Term ID.
+ *
+ * @return string
  */
 function add_podcasting_term_feed_link_column( $string, $column_name, $term_id ) {
 
@@ -377,7 +433,10 @@ add_filter( 'manage_' . TAXONOMY_NAME . '_custom_column', __NAMESPACE__ . '\add_
 
 /**
  * Add a custom column for the podcast feed link.
- * @param Array $columns An array of columns
+ *
+ * @param array $columns An array of columns
+ *
+ * @return array
  */
 function add_custom_term_columns( $columns ) {
 	$columns['feedurl'] = 'Feed URL';
@@ -628,9 +687,9 @@ function get_podcasting_categories_options() {
 function get_podcasting_language_options() {
 	$lang = '';
 	if ( is_admin() ) {
-		global $tag_ID;
+		global $tag_ID; // WPCS: @codingStandardsIgnoreLine - we can't control WP global names.
 		// Are we on the term edit screen?
-		$term_id = $tag_ID;
+		$term_id = $tag_ID; // WPCS: @codingStandardsIgnoreLine - we can't control WP global names.
 		if ( $term_id ) {
 			$lang = get_term_meta( $term_id, 'podcasting_language', true );
 		}

--- a/includes/datatypes.php
+++ b/includes/datatypes.php
@@ -161,8 +161,25 @@ function add_podcasting_term_add_meta_fields( $term ) {
 function the_field( $field, $value = '', $term_id = false ) {
 	switch ( $field['type'] ) {
 		case 'language':
-			echo $field['data'];
-		break;
+			echo wp_kses(
+				$field['data'],
+				array(
+					'select'   => array(
+						'name' => array(),
+						'id'   => array(),
+					),
+					'optgroup' => array(
+						'label' => array(),
+					),
+					'option'   => array(
+						'value'          => array(),
+						'lang'           => array(),
+						'data-installed' => array(),
+						'selected'       => array(),
+					),
+				)
+			);
+			break;
 		case 'textfield':
 		?>
 			<input


### PR DESCRIPTION
This PR introduces a language selector to the Podcast term edit screen to allow selecting a language per podcast. Closes #54.