### PR TITLE
Correct 10up wp mock referenced version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "php": ">=7.0"
   },
   "require-dev": {
-    "10up/wp_mock": "dev-dev",
+    "10up/wp_mock": "dev-master",
     "10up/phpcs-composer": "dev-master"
   }
 }


### PR DESCRIPTION
Hi @helen ,

Today I ran into this problem when executing composer install inside the plugin folder:

![Screen Shot 2019-05-05 at 12 04 01 AM](https://user-images.githubusercontent.com/31049169/57188769-b4a98080-6ec9-11e9-87ee-b0ff57917312.png)

It looks like    ` "10up/wp_mock": "dev-dev",` does not exist from what I see on https://packagist.org/packages/10up/wp_mock

Would switching to dev-master be a solution for this? This seems to solve the problem for me.

Thanks!