### PR TITLE
Fix allowed types in podcast block when selecting file.

### DIFF
--- a/assets/js/edit.js
+++ b/assets/js/edit.js
@@ -186,7 +186,7 @@ class Edit extends Component {
 						onSelect={ onSelectAttachment }
 						onSelectURL={ onSelectURL }
 						accept="audio/*"
-						type="audio"
+						allowedTypes={ [ 'audio' ] }
 						value={ this.props.attributes }
 					/>
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Currently it is possible to add non-audio files to the podcast block - e.g. an image. 

Looking at the code, it looks like the intention was that this is restricted to audio files only, but the prop passed to [MediaPlaceholder](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/media-placeholder/README.md) is implemented incorrectly (or Gutenberg has changed the props at some point!)

The prop should be allowedTypes, and the value should be an array of types.

### Alternate Designs

None

### Benefits

Prevent adding images or other files to podcasts.

### Possible Drawbacks

None

### Verification Process

Tested locally.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
