### PR TITLE
Fix: Podcast post meta still remains after deleting the podcast block

### DIFF
--- a/assets/js/edit.js
+++ b/assets/js/edit.js
@@ -31,10 +31,9 @@ class Edit extends Component {
 	}
 
 	/**
-	 * When the component is removed, we'll set the the post meta to null so it is deleted on save.
+	 * When the component is removed, we'll remove any assigned Podcast taxonomies.
 	 */
 	componentWillUnmount() {
-		// Remove any assigned Podcast taxonomies.
 		wp.data.dispatch( 'core/editor' ).editPost( { [ 'podcasting_podcasts' ]:[] } );
 	}
 

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -68,3 +68,19 @@ function load_translations() {
 	}
 }
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\load_translations' );
+
+/**
+ * Delete left over post meta after deleting podcast block.
+ */
+function block_editor_meta_cleanup( $post, $request, $creating ) {
+	if ( $creating ) {
+		return;
+	}
+
+	if ( has_block( 'podcasting/podcast', $post->ID ) ) {
+		return;
+	}
+
+	\tenup_podcasting\helpers\delete_all_podcast_meta( $post->ID );
+}
+add_action( 'rest_after_insert_post', __NAMESPACE__ . '\block_editor_meta_cleanup', 10, 3 );

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -62,3 +62,19 @@ function get_podcast_meta_from_url( $url ) {
 		return $podcast_meta;
 	}
 }
+
+/**
+ * Delete all podcast meta for a post.
+ *
+ * @param int $post_id Post ID.
+ */
+function delete_all_podcast_meta( $post_id ) {
+	if ( metadata_exists( 'post', $post_id, 'podcast_url' ) ) {
+		delete_post_meta( $post_id, 'podcast_url' );
+		delete_post_meta( $post_id, 'podcast_filesize' );
+		delete_post_meta( $post_id, 'podcast_duration' );
+		delete_post_meta( $post_id, 'podcast_mime' );
+		delete_post_meta( $post_id, 'podcast_captioned' );
+		delete_post_meta( $post_id, 'podcast_explicit' );
+	}
+}


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR utilizes `rest_after_insert_post` action to check and delete podcast meta if the podcast block is deleted from posts.
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Verification Process
1. Create a new podcast and an episode for that podcast. See the podcast meta in meta table.
2. Edit the episode, delete the podcast block, and save changes.
4. Don't see the podcast meta still remains in the meta table.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
Fixes #88
<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
