### PR TITLE
Create no-response.yml GitHub Action

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,30 @@
+name: No Response
+
+# **What it does**: Closes issues where the original author doesn't respond to a request for information.
+# **Why we have it**: To remove the need for maintainers to remember to check back on issues periodically to see if contributors have responded.
+# **Who does it impact**: Everyone that works on docs or docs-internal.
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule for five minutes after the hour, every hour
+    - cron: '5 * * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@v0.5.0
+        with:
+          token: ${{ github.token }}
+          daysUntilClose: 14 # Number of days of inactivity before an Issue is closed for lack of response
+          responseRequiredLabel: "reporter feedback" # Label indicating that a response from the original author is required
+          closeComment: >
+            This issue has been automatically closed because there has been no response
+            to our request for more information. With only the
+            information that is currently in the issue, we don't have enough information
+            to take action. Please reach out if you have or find the answers we need so
+            that we can investigate further. See [this blog post on bug reports and the
+            importance of repro steps](https://www.lee-dohm.com/2015/01/04/writing-good-bug-reports/)
+            for more information about the kind of information that may be helpful.


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR adds a GitHub Action that will auto-close issues with the `reporter feedback` label if there is no response from the original reporter within 14 days. If the original reporter responds after the 14 days, the issue will be auto-reopened. Anyone else is also able to reopen the issue, this PR just helps close stale issues automatically.

### Alternate Designs

Manually maintain unresponded to issues and remember to close them.

### Benefits

Automates closing of stale issues.

### Possible Drawbacks

none identified

### Verification Process

Already tested on [ElasticPress](https://github.com/10up/ElasticPress/blob/develop/.github/workflows/no-response.yml) and working well there.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

```
### Added
- Issue management automation via GitHub Actions (props @jeffpaul).
```