### PR TITLE
ci: fix minimum WP version

### DIFF
--- a/.github/workflows/test-branch.yml
+++ b/.github/workflows/test-branch.yml
@@ -15,7 +15,7 @@ jobs:
         core:
           - {name: 'WP latest', version: 'latest'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#4.6.0'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#4.6'}
 
     steps:
     - name: Checkout


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR fixes the minimum WordPress version used by `wp-env`. WordPress doesn't have a `4.6.0` tag but only has the `4.6` one. This issue was introduced by #117.