### PR TITLE
Attempt to fix #134 is_feed called too early

### DIFF
--- a/simple-podcasting.php
+++ b/simple-podcasting.php
@@ -103,15 +103,17 @@ add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\podcasting_edit_term_enqu
 /**
  * Load the file containing iTunes specific feed hooks.
  *
+ * @param  WP_Query $query The query being parsed.
+ *
  * @uses includes/customize-feed.php
  */
-function custom_feed() {
+function custom_feed( \WP_Query $query ) {
 	if ( is_admin() || ! podcasting_is_enabled() ) {
 		return;
 	}
 
 	// Is this a feed for a term in the podcasting taxonomy?
-	if ( is_feed() && is_tax( TAXONOMY_NAME ) ) {
+	if ( $query->is_feed() && $query->is_tax( TAXONOMY_NAME ) ) {
 		remove_action( 'rss2_head', 'rss2_blavatar' );
 		remove_action( 'rss2_head', 'rss2_site_icon' );
 		remove_filter( 'the_excerpt_rss', 'add_bug_to_feed', 100 );
@@ -125,11 +127,13 @@ function custom_feed() {
 		require_once PODCASTING_PATH . 'includes/customize-feed.php';
 	}
 }
-add_action( 'parse_query', __NAMESPACE__ . '\custom_feed' );
+add_action( 'parse_query', __NAMESPACE__ . '\custom_feed', 10, 1 );
 
 
 /**
  * Initialize the edit screen if podcasting is enabled.
+ *
+ * @uses includes/post-meta-box.php
  */
 function setup_edit_screen() {
 	if ( podcasting_is_enabled() ) {


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This tries to fix a PHP warning that occurs when using the latest version, it is too early to call `is_feed` on the main query, but we don't need to, we're handed the query object on a silver platter so lets use that instead.

Closes #134

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

This seemed like the most straightforward way to fix it

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

`¯\_(ツ)_/¯`

### Verification Process

None as of yet, just trying to be helpful and start the ball rolling by making the PR as quickly as possible

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Fixed - Bug fix for is_feed being called too early

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @tomjn
