### PR TITLE
Feed item filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/).
 
 ## [Unreleased]
+- Filter `simple_podcasting_feed_item` to modify RSS feed item data before output (pros [@cadic](https://github.com/cadic)).
 
 ## [1.2.1] - 2021-12-16
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 * [Create Podcast](#create-your-podcast)
 * [Add Content to Podcast](#add-content-to-your-podcast)
 * [Submit Podcast Feed to Apple Podcasts](#submit-your-podcast-feed-to-apple-podcasts)
+* [Control how many episodes are listed on the feed](#control-how-many-episodes-are-listed-on-the-feed)
+* [Customize RSS feed](#customize-rss-feed)
 * [Contributing](#contributing)
 
 ## Overview
@@ -88,6 +90,20 @@ function podcasting_feed_episodes_per_page( $qty ) {
 	return 300;
 }
 
+```
+
+## Customize RSS feed
+
+If you want to modify RSS feed items output, there is a filter for that:
+
+```
+function podcasting_feed_item_filter( $feed_item = array(), $post_id = null, $term_id = null ) {
+	if ( 42 === $post_id ) {
+		$feed_item['keywords'] = 'one,two,three';
+	}
+	return $feed_item;
+}
+add_filter( 'simple_podcasting_feed_item', 'podcasting_feed_item_filter', 10, 3 );
 ```
 
 ## Support Level

--- a/includes/customize-feed.php
+++ b/includes/customize-feed.php
@@ -178,7 +178,7 @@ function feed_item() {
 		'keywords'  => '',
 		'image'     => '',
 		'summary'   => '',
-		'subtitle'  => wp_trim_words( $excerpt, 10, '&#8230;' ),
+		'subtitle'  => '',
 		'duration'  => get_post_meta( $post->ID, 'podcast_duration', true ),
 	);
 

--- a/includes/customize-feed.php
+++ b/includes/customize-feed.php
@@ -171,70 +171,86 @@ function feed_item() {
 		return false;
 	}
 
-	$author = get_option( 'podcasting_talent_name' );
-	if ( empty( $author ) ) {
-		$author = get_the_author();
+	$feed_item = array(
+		'author'    => get_option( 'podcasting_talent_name' ),
+		'explicit'  => get_post_meta( $post->ID, 'podcast_explicit', true ),
+		'captioned' => get_post_meta( $post->ID, 'podcast_captioned', true ),
+		'keywords'  => '',
+		'image'     => '',
+		'summary'   => '',
+		'subtitle'  => wp_trim_words( $excerpt, 10, '&#8230;' ),
+		'duration'  => get_post_meta( $post->ID, 'podcast_duration', true ),
+	);
+
+	if ( empty( $feed_item['author'] ) ) {
+		$feed_item['author'] = get_the_author();
 	}
-
-	echo '<itunes:author>' . esc_html( $author ) . "</itunes:author>\n";
-
-	$explicit = get_post_meta( $post->ID, 'podcast_explicit', true );
 
 	// fall back to the podcast setting.
-	if ( empty( $explicit ) ) {
-		$explicit = get_term_meta( $term->term_id, 'podcasting_explicit', true );
+	if ( empty( $feed_item['explicit'] ) ) {
+		$feed_item['explicit'] = get_term_meta( $term->term_id, 'podcasting_explicit', true );
 	}
 
-	echo '<itunes:explicit>';
-
-	if ( empty( $explicit ) ) {
-		echo 'no';
-	} else {
-		echo esc_html( $explicit );
-	}
-
-	echo "</itunes:explicit>\n";
-
-	$captioned = get_post_meta( $post->ID, 'podcast_captioned', true );
-
-	if ( $captioned ) {
-		echo "<itunes:isClosedCaptioned>Yes</itunes:isClosedCaptioned>\n";
+	// "no" explicit by default
+	if ( empty( $feed_item['explicit'] ) ) {
+		$feed_item['explicit'] = 'no';
 	}
 
 	// Add the featured image if available.
 	if ( has_post_thumbnail( $post->ID ) ) {
-		$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'post-thumbnail' );
-		if ( ! empty( $image ) ) {
-			if ( is_array( $image ) ) {
-				$image = $image[0];
-			}
-			echo "<itunes:image href='" . esc_url( $image ) . "' />\n";
+		$feed_item['image'] = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'post-thumbnail' );
+		if ( ! empty( $feed_item['image'] ) && is_array( $feed_item['image'] ) ) {
+			$feed_item['image'] = $feed_item['image'][0];
 		}
 	}
 
-	// @todo add a filter here
-	$keywords = '';
-	if ( ! empty( $keywords ) ) {
-		echo '<itunes:keywords>' . esc_html( $keywords ) . "</itunes:keywords>\n";
-	}
-
 	if ( has_excerpt() ) {
-		$excerpt = get_the_excerpt();
+		$feed_item['summary'] = get_the_excerpt();
 	} else {
-		$excerpt = get_term_meta( $term->term_id, 'podcasting_summary', true );
+		$feed_item['summary'] = get_term_meta( $term->term_id, 'podcasting_summary', true );
 	}
-	$excerpt = apply_filters( 'the_excerpt_rss', $excerpt );
+	$feed_item['summary'] = apply_filters( 'the_excerpt_rss', $feed_item['summary'] );
 
-	echo '<itunes:summary>' . esc_html( wp_strip_all_tags( $excerpt ) ) . "</itunes:summary>\n";
+	$feed_item['subtitle'] = wp_trim_words( $feed_item['summary'], 10, '&#8230;' );
 
-	$subtitle = wp_trim_words( $excerpt, 10, '&#8230;' );
+	/**
+	 * Filter podcasting feed item data
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param array $feed_item {
+	 *     Item data to filter.
+	 *
+	 *     @type string $author    Podcast author.
+	 *     @type string $explicit  Explicit content (yes|no|clean).
+	 *     @type string $captioned Closed Captioned ("1"|"0"). Optional.
+	 *     @type string $keywords  Episode keywords. Optional.
+	 *     @type string $image     Episode image. Optional.
+	 *     @type string $summary   Episode summary.
+	 *     @type string $subtitle  Episode subtitle.
+	 *     @type string $duration  Episode duration (HH:MM). Optional.
+	 * }
+	 * @param int $post->ID Podcast episode post ID.
+	 * @param int $term->term_id Podcast term ID.
+	 */
+	$feed_item = apply_filters( 'simple_podcasting_feed_item', $feed_item, $post->ID, $term->term_id );
 
-	echo '<itunes:subtitle>' . esc_html( $subtitle ) . "</itunes:subtitle>\n";
-
-	// Add an enclosure duration if available.
-	$duration = get_post_meta( $post->ID, 'podcast_duration', true );
-	if ( ! empty( $duration ) ) {
-		echo '<itunes:duration>' . esc_html( $duration ) . "</itunes:duration>\n";
+	// Output all custom RSS tags.
+	echo '<itunes:author>' . esc_html( $feed_item['author'] ) . "</itunes:author>\n";
+	echo '<itunes:explicit>' . esc_html( $feed_item['explicit'] ) . "</itunes:explicit>\n";
+	if ( $feed_item['captioned'] ) {
+		echo "<itunes:isClosedCaptioned>Yes</itunes:isClosedCaptioned>\n";
+	}
+	if ( ! empty( $feed_item['image'] ) ) {
+		echo "<itunes:image href='" . esc_url( $feed_item['image'] ) . "' />\n";
+	}
+	if ( ! empty( $feed_item['keywords'] ) ) {
+		echo '<itunes:keywords>' . esc_html( $feed_item['keywords'] ) . "</itunes:keywords>\n";
+	}
+	echo '<itunes:summary>' . esc_html( wp_strip_all_tags( $feed_item['summary'] ) ) . "</itunes:summary>\n";
+	echo '<itunes:subtitle>' . esc_html( $feed_item['subtitle'] ) . "</itunes:subtitle>\n";
+	if ( ! empty( $feed_item['duration'] ) ) {
+		echo '<itunes:duration>' . esc_html( $feed_item['duration'] ) . "</itunes:duration>\n";
 	}
 }
 add_action( 'rss2_item', __NAMESPACE__ . '\feed_item' );

--- a/readme.txt
+++ b/readme.txt
@@ -68,6 +68,20 @@ function podcasting_feed_episodes_per_page( $qty ) {
 }
 `
 
+=== Customize RSS feed ===
+
+If you want to modify RSS feed items output, there is a filter for that:
+
+`<?php
+function podcasting_feed_item_filter( $feed_item = array(), $post_id = null, $term_id = null ) {
+	if ( 42 === $post_id ) {
+		$feed_item['keywords'] = 'one,two,three';
+	}
+	return $feed_item;
+}
+add_filter( 'simple_podcasting_feed_item', 'podcasting_feed_item_filter', 10, 3 );
+`
+
 === Technical Notes ===
 
 * Requires PHP 5.3+.

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -4,7 +4,7 @@
  * Starts up WP_Mock and requires the files needed for testing.
  */
 
-define( 'TEST_PLUGIN_DIR', dirname( dirname(__DIR__) ) . '/' );
+define( 'TEST_PLUGIN_DIR', dirname( dirname( __DIR__ ) ) . '/' );
 
 // First we need to load the composer autoloader so we can use WP Mock
 require_once TEST_PLUGIN_DIR . '/vendor/autoload.php';
@@ -18,9 +18,9 @@ define( 'PODCASTING_URL', 'https://example.com/wp-content/plugins/simple-podcast
 define( 'TAXONOMY_NAME', 'podcasting_podcasts' );
 define( 'PODCASTING_ITEMS_PER_PAGE', 250 );
 
-include TEST_PLUGIN_DIR . 'includes/blocks.php';
-include TEST_PLUGIN_DIR . 'includes/customize-feed.php';
-include TEST_PLUGIN_DIR . 'includes/datatypes.php';
-include TEST_PLUGIN_DIR . 'includes/helpers.php';
-include TEST_PLUGIN_DIR . 'includes/post-meta-box.php';
-include TEST_PLUGIN_DIR . 'includes/rest-external-url.php';
+require TEST_PLUGIN_DIR . 'includes/blocks.php';
+require TEST_PLUGIN_DIR . 'includes/customize-feed.php';
+require TEST_PLUGIN_DIR . 'includes/datatypes.php';
+require TEST_PLUGIN_DIR . 'includes/helpers.php';
+require TEST_PLUGIN_DIR . 'includes/post-meta-box.php';
+require TEST_PLUGIN_DIR . 'includes/rest-external-url.php';

--- a/tests/unit/test-customize-feed.php
+++ b/tests/unit/test-customize-feed.php
@@ -87,21 +87,190 @@ class CustomizeFeedTests extends TestCase {
 		);
 	}
 
-	public function test_pre_get_posts_feed()
-	{
-		$query_mock = \Mockery::mock('\WP_Query');
+	public function test_pre_get_posts_feed() {
+		 $query_mock = \Mockery::mock( '\WP_Query' );
 
-		$query_mock->shouldReceive('is_feed')->andReturn( true );
+		$query_mock->shouldReceive( 'is_feed' )->andReturn( true );
 
 		\WP_Mock::onFilter( 'simple_podcasting_episodes_per_page' )
 			->with( PODCASTING_ITEMS_PER_PAGE )
 			->reply( 100 );
 
-		$query_mock->shouldReceive('set')->with( 'posts_per_rss', 100 );
+		$query_mock->shouldReceive( 'set' )->with( 'posts_per_rss', 100 );
 
 		$this->assertNull(
 			tenup_podcasting\pre_get_posts( $query_mock ),
 			'tenup_podcasting\pre_get_posts() should update WP_Query->posts_per_rss with filtered value.'
+		);
+	}
+
+	/**
+	 * @test - The most basic of PHPUnit tests to make sure it's working.
+	 * @dataProvider data_provider_for_test_feed_item
+	 */
+	public function test_feed_item( $talent_option, $post_data, $term, $post_author, $post_meta, $term_meta, $filters, $expected ) {
+		global $post;
+		$post = $post_data;
+
+		\WP_Mock::userFunction(
+			'get_queried_object',
+			array(
+				'times'  => 1,
+				'return' => $term,
+			)
+		);
+
+		\WP_Mock::userFunction( 'get_option' )
+			->with( 'podcasting_talent_name' )
+			->andReturn( $talent_option );
+
+		\WP_Mock::userFunction( 'get_post_meta' )
+			->andReturnUsing(
+				function( $id, $key, $_ ) use ( $post_meta ) {
+					return isset( $post_meta[ $key ] ) ? $post_meta[ $key ] : false;
+				}
+			);
+
+		\WP_Mock::userFunction( 'get_term_meta' )
+			->andReturnUsing(
+				function( $id, $key, $_ ) use ( $term_meta ) {
+					return isset( $term_meta[ $key ] ) ? $term_meta[ $key ] : false;
+				}
+			);
+
+		\WP_Mock::userFunction( 'get_the_author' )
+			->andReturn( $post_author );
+
+		\WP_Mock::userFunction( 'has_post_thumbnail' )
+			->andReturn( isset( $post->thumbnail ) );
+
+		\WP_Mock::userFunction( 'wp_get_attachment_image_src' )
+			->andReturn( isset( $post->thumbnail ) ? $post->thumbnail : false );
+
+		\WP_Mock::passthruFunction( 'get_post_thumbnail_id' );
+		\WP_Mock::passthruFunction( 'wp_strip_all_tags' );
+
+		\WP_Mock::userFunction( 'has_excerpt' )
+			->andReturn( isset( $post->excerpt ) );
+		\WP_Mock::userFunction( 'get_the_excerpt' )
+			->andReturn( isset( $post->excerpt ) ? $post->excerpt : '' );
+
+		\WP_Mock::userFunction( 'wp_trim_words' )
+			->andReturnUsing(
+				function ( $text, $num_words, $more ) {
+					return strlen( $text ) > 30 ? 'Short Excerpt' : $text;
+				}
+			);
+
+		ob_start();
+		$result = tenup_podcasting\feed_item();
+		$output = ob_get_clean();
+
+		if ( is_bool( $expected ) ) {
+			$this->assertSame( $expected, $result );
+		} elseif ( is_array( $expected ) ) {
+			foreach ( $expected as $message => $regex_string ) {
+				$this->assertRegExp( $regex_string, $output, $message );
+			}
+		}
+	}
+
+	public function data_provider_for_test_feed_item() {
+		return array(
+			'Term not found' => array(
+				'talent_option' => '',
+				'post_data'     => (object) array(),
+				'term'          => false,
+				'post_author'   => '',
+				'post_meta'     => array(),
+				'term_meta'     => array(),
+				'filters'       => false,
+				'expected'      => false,
+			),
+			'Mixed Test 1'   => array(
+				'talent_option' => 'Talent from settings',
+				'post_data'     => (object) array(
+					'ID'        => 42,
+					'excerpt'   => 'Post Excerpt',
+					'thumbnail' => 'http://example.com/image.jpg',
+				),
+				'term'          => (object) array( 'term_id' => 2 ),
+				'post_author'   => 'Post Author',
+				'post_meta'     => array(
+					'podcast_explicit'  => '',
+					'podcast_captioned' => '',
+					'podcast_duration'  => '',
+				),
+				'term_meta'     => array(
+					'podcasting_explicit' => '',
+					'podcasting_summary'  => '',
+				),
+				'filters'       => false,
+				'expected'      => array(
+					'Talent from settings'          => '/<itunes:author>Talent from settings<\/itunes:author>/',
+					'No explicit if all defaults'   => '/<itunes:explicit>no<\/itunes:explicit>/',
+					'Doesnt contain closed caption' => '/^((?!isClosedCaptioned).)*$/s',
+					'Episode thumbnail'             => "/<itunes:image href='http:\/\/example\.com\/image\.jpg' \/>/",
+					'Post excerpt as summary'       => '/<itunes:summary>Post Excerpt<\/itunes:summary>/',
+					'Post excerpt as subtitle'      => '/<itunes:subtitle>Post Excerpt<\/itunes:subtitle>/',
+					'Duration is empty'             => '/^((?!<itunes:duration>).)*$/s',
+				),
+			),
+			'Mixed Test 2'   => array(
+				'talent_option' => '',
+				'post_data'     => (object) array(
+					'ID'      => 42,
+					'excerpt' => 'Very Long Post Excerpt Very Long Post Excerpt Very Long Post Excerpt Very Long Post Excerpt',
+				),
+				'term'          => (object) array( 'term_id' => 2 ),
+				'post_author'   => 'Post Author',
+				'post_meta'     => array(
+					'podcast_explicit'  => 'yes',
+					'podcast_captioned' => '1',
+					'podcast_duration'  => '1:23',
+				),
+				'term_meta'     => array(
+					'podcasting_explicit' => '',
+					'podcasting_summary'  => '',
+				),
+				'filters'       => false,
+				'expected'      => array(
+					'Post Author'              => '/<itunes:author>Post Author<\/itunes:author>/',
+					'Explicit from episode'    => '/<itunes:explicit>yes<\/itunes:explicit>/',
+					'Contain Closed Captioned' => '/<itunes:isClosedCaptioned>Yes<\/itunes:isClosedCaptioned>/',
+					'Doesnt contain thumbnail' => '/^((?!<itunes:image).)*$/s',
+					'Long Summary'             => '/<itunes:summary>Very Long Post Excerpt Very Long Post Excerpt Very Long Post Excerpt Very Long Post Excerpt<\/itunes:summary>/',
+					'Short Subtitle'           => '/<itunes:subtitle>Short Excerpt<\/itunes:subtitle>/',
+					'Duration'                 => '/<itunes:duration>1:23<\/itunes:duration>/',
+				),
+			),
+			'Mixed Test 3'   => array(
+				'talent_option' => '',
+				'post_data'     => (object) array(
+					'ID' => 42,
+				),
+				'term'          => (object) array( 'term_id' => 2 ),
+				'post_author'   => 'Post Author',
+				'post_meta'     => array(
+					'podcast_explicit'  => '',
+					'podcast_captioned' => '1',
+					'podcast_duration'  => '1:23',
+				),
+				'term_meta'     => array(
+					'podcasting_explicit' => 'clean',
+					'podcasting_summary'  => 'Summary from plugin settings',
+				),
+				'filters'       => false,
+				'expected'      => array(
+					'Post Author'                   => '/<itunes:author>Post Author<\/itunes:author>/',
+					'Explicit from plugin settings' => '/<itunes:explicit>clean<\/itunes:explicit>/',
+					'Contain Closed Captioned'      => '/<itunes:isClosedCaptioned>Yes<\/itunes:isClosedCaptioned>/',
+					'Doesnt contain thumbnail'      => '/^((?!<itunes:image).)*$/s',
+					'Summary from plugin settings'  => '/<itunes:summary>Summary from plugin settings<\/itunes:summary>/',
+					'Subtitle from plugin settings' => '/<itunes:subtitle>Summary from plugin settings<\/itunes:subtitle>/',
+					'Duration'                      => '/<itunes:duration>1:23<\/itunes:duration>/',
+				),
+			),
 		);
 	}
 }


### PR DESCRIPTION
### Description of the Change

With this PR we introduce new filter `simple_podcasting_feed_item` to allow modification of each feed item before output to RSS2.

To be able to filter, `tenup_podcasting\feed_item()` is rerfactored:
- all data is saved into an array
- array is passed through the filter
- output is made as single portion of code

Closes #17

### Alternate Designs

n/a

### Possible Drawbacks

not discovered

### Verification Process

1. Create new Podcast
2. Add new post with Podcast Block and connect it with the Podcast
3. Add filter to `simple_podcasting_feed_item` (example below)
4. Check Podcast RSS — expected to match filter modifications

Example of filter:

```
function podcasting_feed_item_filter( $feed_item = array(), $post_id = null, $term_id = null ) {
	$feed_item['keywords'] = 'one,two,three';
	return $feed_item;
}
add_filter( 'simple_podcasting_feed_item', 'podcasting_feed_item_filter', 10, 3 );
```

Should result in keywords added to each feed item:

```
<itunes:keywords>one,two,three</itunes:keywords>
```

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Added - Filter 'simple_podcasting_feed_item' to modify RSS feed item data before output

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @cadic