### PR TITLE
Cypress fix with new WordPress 5.9 selectors

### DIFF
--- a/tests/cypress/integration/block.test.js
+++ b/tests/cypress/integration/block.test.js
@@ -6,9 +6,31 @@ describe( 'Admin can publish posts with podcast block', () => {
 	it( 'Can insert the block and publish the post', () => {
 		cy.visitAdminPage( 'post-new.php' );
 		cy.get( 'button[aria-label="Close dialog"]' ).click();
-		cy.get( '#post-title-0' ).click().type( 'Test episode' );
-		cy.get( '.edit-post-header-toolbar__inserter-toggle' ).click();
-		cy.get( '#block-editor-inserter__search-0' ).type( 'Podcast' );
+
+		cy.get('body')
+			.then(
+				($body) =>
+					$body.find('h1.editor-post-title__input').length
+						? 'h1.editor-post-title__input' // WordPress 5.9
+						: '#post-title-0' // 5.8.1 and below
+			)
+			.then((selector) => {
+				cy.get(selector).click().type('Test episode');
+			});
+
+		cy.get('.edit-post-header-toolbar__inserter-toggle').click();
+
+		cy.get('body')
+			.then(
+				($body) =>
+					$body.find('#components-search-control-0').length
+						? '#components-search-control-0' // WordPress 5.9
+						: '#block-editor-inserter__search-0' // 5.8.1 and below
+			)
+			.then((selector) => {
+				cy.get(selector).type('Podcast');
+			});
+
 		cy.get( '.editor-block-list-item-podcasting-podcast' ).click();
 		cy.get( '.edit-post-header-toolbar__inserter-toggle' ).click();
 		cy.get( '.wp-block-podcasting-podcast input[type="file"]' ).attachFile(

--- a/tests/cypress/integration/block.test.js
+++ b/tests/cypress/integration/block.test.js
@@ -6,11 +6,15 @@ describe( 'Admin can publish posts with podcast block', () => {
 	it( 'Can insert the block and publish the post', () => {
 		cy.visitAdminPage( 'post-new.php' );
 		cy.get( 'button[aria-label="Close dialog"]' ).click();
-		cy.get('h1.editor-post-title__input, #post-title-0').first().as('title-input');
-		cy.get('@title-input').click().type('Test episode');
-		cy.get('.edit-post-header-toolbar__inserter-toggle').click();
-		cy.get('#components-search-control-0, #block-editor-inserter__search-0').first().as('block-search');
-		cy.get('@block-search').click().type('Podcast');
+		cy.get( 'h1.editor-post-title__input, #post-title-0' )
+			.first()
+			.as( 'title-input' );
+		cy.get( '@title-input').click().type('Test episode' );
+		cy.get( '.edit-post-header-toolbar__inserter-toggle' ).click();
+		cy.get( '#components-search-control-0, #block-editor-inserter__search-0' )
+			.first()
+			.as( 'block-search' );
+		cy.get( '@block-search' ).click().type( 'Podcast' );
 		cy.get( '.editor-block-list-item-podcasting-podcast' ).click();
 		cy.get( '.edit-post-header-toolbar__inserter-toggle' ).click();
 		cy.get( '.wp-block-podcasting-podcast input[type="file"]' ).attachFile(

--- a/tests/cypress/integration/block.test.js
+++ b/tests/cypress/integration/block.test.js
@@ -6,31 +6,11 @@ describe( 'Admin can publish posts with podcast block', () => {
 	it( 'Can insert the block and publish the post', () => {
 		cy.visitAdminPage( 'post-new.php' );
 		cy.get( 'button[aria-label="Close dialog"]' ).click();
-
-		cy.get('body')
-			.then(
-				($body) =>
-					$body.find('h1.editor-post-title__input').length
-						? 'h1.editor-post-title__input' // WordPress 5.9
-						: '#post-title-0' // 5.8.1 and below
-			)
-			.then((selector) => {
-				cy.get(selector).click().type('Test episode');
-			});
-
+		cy.get('h1.editor-post-title__input, #post-title-0').first().as('title-input');
+		cy.get('@title-input').click().type('Test episode');
 		cy.get('.edit-post-header-toolbar__inserter-toggle').click();
-
-		cy.get('body')
-			.then(
-				($body) =>
-					$body.find('#components-search-control-0').length
-						? '#components-search-control-0' // WordPress 5.9
-						: '#block-editor-inserter__search-0' // 5.8.1 and below
-			)
-			.then((selector) => {
-				cy.get(selector).type('Podcast');
-			});
-
+		cy.get('#components-search-control-0, #block-editor-inserter__search-0').first().as('block-search');
+		cy.get('@block-search').click().type('Podcast');
 		cy.get( '.editor-block-list-item-podcasting-podcast' ).click();
 		cy.get( '.edit-post-header-toolbar__inserter-toggle' ).click();
 		cy.get( '.wp-block-podcasting-podcast input[type="file"]' ).attachFile(


### PR DESCRIPTION
### Description of the Change

Since WordPress 5.9, Block Editor has changed some of elements. Old id's are no longer relevant.

This PR adds new selectors to the Cypress test suite, with fallback for old selectors from 5.8.1 and below.

Closes #145 

### Verification Process

Test with latest WordPress:
1. `npm run wp-env start` (latest WordPress core by default)
2. `npm run cypress:run`

Don't forget to reset the environment between tests:
`npm run wp-env stop && npm run wp-env destroy && rm -rf .wp-env.json`

Test with pre-5.9 WordPress:
1. `./tests/bin/set-core-version.js WordPress/WordPress#5.8.1`
2. `npm run wp-env start`
3. `npm run cypress:run`

Both runs expected to succeed.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Fixed - Cypress tests with WordPress 5.9

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @cadic, @felipeelia 
