### PR TITLE
Fix/add enclosure to feed item

### DIFF
--- a/assets/js/blocks.js
+++ b/assets/js/blocks.js
@@ -67,7 +67,12 @@ export default registerBlockType(
 				source: 'meta',
 				meta: 'podcast_explicit',
 				default: 'no',
-			}
+			},
+			enclosure: {
+				type: 'string',
+				source: 'meta',
+				meta: 'enclosure',
+			},
 		},
 		transforms,
 

--- a/assets/js/edit.js
+++ b/assets/js/edit.js
@@ -76,6 +76,7 @@ class Edit extends Component {
 				filesize,
 				duration,
 				caption: attachment.title,
+				enclosure: attachment.url + "\n" + filesize + "\n" + mime
 			} );
 			this.setState( { src: attachment.url } );
 		};

--- a/includes/customize-feed.php
+++ b/includes/customize-feed.php
@@ -264,7 +264,7 @@ add_action( 'rss2_item', __NAMESPACE__ . '\feed_item' );
 /**
  * Displays the enclosure feed for podcasts.
  *
- * @param  int $post The post ID.
+ * @param  WP_Post $post The post object.
  *
  * @return void
  */
@@ -281,18 +281,18 @@ function display_rss_enclosure( $post ) {
 		"' type='" .
 		esc_attr( $podcast_mime ) .
 		"' />\n";
-	}
 
-	echo wp_kses(
-		$enclosure,
-		array(
-			'enclosure' => array(
-				'url'    => array(),
-				'length' => array(),
-				'type'   => array(),
-			),
-		)
-	);
+		echo wp_kses(
+			$enclosure,
+			array(
+				'enclosure' => array(
+					'url'    => array(),
+					'length' => array(),
+					'type'   => array(),
+				),
+			)
+		);
+	}
 }
 
 /**

--- a/includes/customize-feed.php
+++ b/includes/customize-feed.php
@@ -235,6 +235,12 @@ function feed_item() {
 	 */
 	$feed_item = apply_filters( 'simple_podcasting_feed_item', $feed_item, $post->ID, $term->term_id );
 
+	// Output enclosure if it's not present in the post
+	$enclosure = get_post_meta( $post->ID, 'enclosure', true );
+	if ( empty( $enclosure ) ) {
+		display_rss_enclosure( $post );
+	}
+
 	// Output all custom RSS tags.
 	echo '<itunes:author>' . esc_html( $feed_item['author'] ) . "</itunes:author>\n";
 	echo '<itunes:explicit>' . esc_html( $feed_item['explicit'] ) . "</itunes:explicit>\n";
@@ -256,15 +262,13 @@ function feed_item() {
 add_action( 'rss2_item', __NAMESPACE__ . '\feed_item' );
 
 /**
- * Adjust the enclosure feed for podcasts.
+ * Displays the enclosure feed for podcasts.
  *
- * @param  string $enclosure The enclosure (media url).
+ * @param  int $post The post ID.
  *
- * @return string            The adjusted enclosure.
+ * @return void
  */
-function rss_enclosure( $enclosure ) {
-	global $post;
-
+function display_rss_enclosure( $post ) {
 	$podcast_url      = get_post_meta( $post->ID, 'podcast_url', true );
 	$podcast_filesize = get_post_meta( $post->ID, 'podcast_filesize', true );
 	$podcast_mime     = get_post_meta( $post->ID, 'podcast_mime', true );
@@ -279,9 +283,17 @@ function rss_enclosure( $enclosure ) {
 		"' />\n";
 	}
 
-	return $enclosure;
+	echo wp_kses(
+		$enclosure,
+		array(
+			'enclosure' => array(
+				'url'    => array(),
+				'length' => array(),
+				'type'   => array(),
+			),
+		)
+	);
 }
-add_filter( 'rss_enclosure', __NAMESPACE__ . '\rss_enclosure' );
 
 /**
  * Generate the category elements from the given option (e.g. podcasting_category_1).
@@ -376,4 +388,3 @@ function pre_get_posts( $query ) {
 
 // Filter the feed query.
 add_action( 'pre_get_posts', __NAMESPACE__ . '\pre_get_posts', 10, 1 );
-

--- a/includes/datatypes.php
+++ b/includes/datatypes.php
@@ -70,6 +70,16 @@ function register_meta() {
 			'single'       => true,
 		)
 	);
+
+	\register_meta(
+		'post',
+		'enclosure',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'string',
+			'single'       => true,
+		)
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_meta' );
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -76,5 +76,6 @@ function delete_all_podcast_meta( $post_id ) {
 		delete_post_meta( $post_id, 'podcast_mime' );
 		delete_post_meta( $post_id, 'podcast_captioned' );
 		delete_post_meta( $post_id, 'podcast_explicit' );
+		delete_post_meta( $post_id, 'enclosure' );
 	}
 }

--- a/includes/post-meta-box.php
+++ b/includes/post-meta-box.php
@@ -131,6 +131,10 @@ function save_meta_box( $post_id ) {
 			update_post_meta( $post_id, 'podcast_filesize', $podcast_meta['filesize'] );
 			update_post_meta( $post_id, 'podcast_duration', $podcast_meta['duration'] );
 			update_post_meta( $post_id, 'podcast_mime', $podcast_meta['podcast_mime'] );
+
+			// Add enclosure meta data
+			$enclosure = $podcast_meta['url'] . PHP_EOL . $podcast_meta['filesize'] . PHP_EOL . $podcast_meta['podcast_mime'];
+			update_post_meta( $post_id, 'enclosure', $enclosure );
 		}
 	}
 

--- a/includes/post-meta-box.php
+++ b/includes/post-meta-box.php
@@ -133,7 +133,8 @@ function save_meta_box( $post_id ) {
 			update_post_meta( $post_id, 'podcast_mime', $podcast_meta['podcast_mime'] );
 
 			// Add enclosure meta data
-			$enclosure = $podcast_meta['url'] . PHP_EOL . $podcast_meta['filesize'] . PHP_EOL . $podcast_meta['podcast_mime'];
+			$enclosure = $podcast_meta['url'] . "\n" . $podcast_meta['filesize'] . "\n" . $podcast_meta['podcast_mime'];
+
 			update_post_meta( $post_id, 'enclosure', $enclosure );
 		}
 	}

--- a/tests/unit/test-blocks.php
+++ b/tests/unit/test-blocks.php
@@ -113,7 +113,7 @@ class BlockTests extends TestCase {
 				'creating'        => false,
 				'has_block'       => false,
 				'metadata_exists' => true,
-				'expected'        => array( 'podcast_url', 'podcast_filesize', 'podcast_duration', 'podcast_mime', 'podcast_captioned', 'podcast_explicit' ),
+				'expected'        => array( 'podcast_url', 'podcast_filesize', 'podcast_duration', 'podcast_mime', 'podcast_captioned', 'podcast_explicit', 'enclosure' ),
 			),
 		);
 	}

--- a/tests/unit/test-customize-feed.php
+++ b/tests/unit/test-customize-feed.php
@@ -149,6 +149,7 @@ class CustomizeFeedTests extends TestCase {
 
 		\WP_Mock::passthruFunction( 'get_post_thumbnail_id' );
 		\WP_Mock::passthruFunction( 'wp_strip_all_tags' );
+		\WP_Mock::passthruFunction( 'wp_kses' );
 
 		\WP_Mock::userFunction( 'has_excerpt' )
 			->andReturn( isset( $post->excerpt ) );
@@ -177,7 +178,7 @@ class CustomizeFeedTests extends TestCase {
 
 	public function data_provider_for_test_feed_item() {
 		return array(
-			'Term not found' => array(
+			'Term not found'              => array(
 				'talent_option' => '',
 				'post_data'     => (object) array(),
 				'term'          => false,
@@ -187,7 +188,7 @@ class CustomizeFeedTests extends TestCase {
 				'filters'       => false,
 				'expected'      => false,
 			),
-			'Mixed Test 1'   => array(
+			'Mixed Test 1'                => array(
 				'talent_option' => 'Talent from settings',
 				'post_data'     => (object) array(
 					'ID'        => 42,
@@ -216,7 +217,7 @@ class CustomizeFeedTests extends TestCase {
 					'Duration is empty'             => '/^((?!<itunes:duration>).)*$/s',
 				),
 			),
-			'Mixed Test 2'   => array(
+			'Mixed Test 2'                => array(
 				'talent_option' => '',
 				'post_data'     => (object) array(
 					'ID'      => 42,
@@ -244,7 +245,7 @@ class CustomizeFeedTests extends TestCase {
 					'Duration'                 => '/<itunes:duration>1:23<\/itunes:duration>/',
 				),
 			),
-			'Mixed Test 3'   => array(
+			'Mixed Test 3'                => array(
 				'talent_option' => '',
 				'post_data'     => (object) array(
 					'ID' => 42,
@@ -269,6 +270,25 @@ class CustomizeFeedTests extends TestCase {
 					'Summary from plugin settings'  => '/<itunes:summary>Summary from plugin settings<\/itunes:summary>/',
 					'Subtitle from plugin settings' => '/<itunes:subtitle>Summary from plugin settings<\/itunes:subtitle>/',
 					'Duration'                      => '/<itunes:duration>1:23<\/itunes:duration>/',
+				),
+			),
+			'Enclosure from podcast meta' => array(
+				'talent_option' => '',
+				'post_data'     => (object) array(
+					'ID' => 42,
+				),
+				'term'          => (object) array( 'term_id' => 2 ),
+				'post_author'   => 'Post Author',
+				'post_meta'     => array(
+					'enclosure'        => false,
+					'podcast_url'      => 'http://example.com/media.mp3',
+					'podcast_filesize' => '42000',
+					'podcast_mime'     => 'audio/mpeg',
+				),
+				'term_meta'     => array(),
+				'filters'       => false,
+				'expected'      => array(
+					'Enclosure' => '/<enclosure url=\'http:\/\/example.com\/media.mp3\' length=\'42000\' type=\'audio\/mpeg\' \/>/',
 				),
 			),
 		);

--- a/tests/unit/test-helpers.php
+++ b/tests/unit/test-helpers.php
@@ -30,7 +30,7 @@ class HelpersTests extends TestCase {
 
 		$this->assertNull(tenup_podcasting\helpers\delete_all_podcast_meta( 42 ));
 
-		$meta_keys = array('podcast_url', 'podcast_filesize', 'podcast_duration', 'podcast_mime', 'podcast_captioned', 'podcast_explicit');
+		$meta_keys = array('podcast_url', 'podcast_filesize', 'podcast_duration', 'podcast_mime', 'podcast_captioned', 'podcast_explicit', 'enclosure');
 		foreach ( $meta_keys as $meta_key ) {
 			\WP_Mock::userFunction( 'delete_post_meta' )->with( 42, $meta_key );
 		}


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

<!-- Enter any applicable Issues here. Example: -->
This PR adds `<enclosure>` tag to feed items - https://github.com/10up/simple-podcasting/issues/147 which is required according to Apple guidelines: https://help.apple.com/itc/podcasts_connect/#/itcb54353390

Currently, there is a function that is meant to add these tags but it's not working, please see below

https://github.com/10up/simple-podcasting/blob/da4578e8ee565ba5f4a53066546dda7d52e56162/includes/customize-feed.php#L258-L284 

### Why it didn't work :point_up_2:

The filter hook `rss_enclosure` is only fired when a meta key titled `enclosure` is present. Unfortunately the meta data is not present and so the function never runs. Please see https://github.com/WordPress/WordPress/blob/63ea8284a3e57ae289ce9ce39a4469cdc317906a/wp-includes/feed.php#L473-L498 

So, when the meta key is present, WordPress automatically adds the `<enclosure>` and we would not need the above filter at all.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->
Two solutions were considered. One is to echo the `<enclosure>` tags inside the feed item function and forget about the meta. The other is to add meta data `<enclosure>` to podcasts post and add the right values so WordPress can do its thing.

Following the first solution alone means ignoring the WordPress way. Following the second solution alone means that feeds of existing podcasts will never have the enclosure tag. The best method is to combine both. Add `enclosure` meta data when podcast posts are created, then just before feed items are displayed, hook into the feed item to check if the tag is present. If it is empty, then display the `enclosure` tag.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None.
### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->
**Test <enclosure> tag is added to feeds**
- Go to Dashboard->Podcasts to create a new podcast
- Go to Posts and create a new post, add an audio file and attach the post to the podcast you created above
- Go to Dashboard->Podcasts and click on the Podcast Feed URL to see the xml feed
- Look for `<enclosure>` tag inside the podcast `<item>` tag you just created above (it will be present)

**Test enclosure meta key is not needed**
- Fetch the ID of the post and run `get_post_custom(ID)`, you should now see `enclosure` key
- Delete the `enclosure` key by doing `delete_post_meta(ID, 'enclosure');`
- Go to Dashboard->Podcasts and click on the Podcast Feed URL to see the xml feed
- Look for `<enclosure>` tag inside the podcast `<item>` tag you just created above (it will be present)

**Test enclosure meta key gets deleted when attachment is removed**
- Go to the Dashboard->Posts and click on the podcast you created.
- Delete the podcast block item
- Run `get_post_custom(ID)`,  the `enclosure` key should be gone

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->
> Fixed - Add `<enclosure>` to feed item.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @davexpression, @cadic.
