### PR TITLE
Create `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# These owners will be the default owners for everything in the repo. Unless a later match takes precedence, @cadic, as primary maintainer will be requested for review when someone opens a Pull Request.
+*                   @cadic
+
+# GitHub and WordPress.org specifics
+/.github/           @jeffpaul
+/.wordpress-org/    @jeffpaul
+CODE_OF_CONDUCT.md  @jeffpaul
+LICENSE.md          @jeffpaul


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR adds a `CODEOWNERS` file in the `.github` directory to specific specific people to set as Reviewers on future Pull Requests.  In general, it sets @cadic (as the primary project maintainer) as the default Reviewer.  Certain directories/files are set to @jeffpaul as Reviewer to ensure that any impacting changes to how the project is published on GitHub and WordPress.org get appropriate review.

After reviewing/merging this in and testing to ensure expected default Reviewers are set within this repo, I'll look to replicate this change to our other repos and document within our Open Source Best Practices.

### Alternate Designs

n/a

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Reviewed [GitHub documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) and public examples to ensure this is set correctly, as well as ensured that repo settings are updated to ensure future PRs take impact from the new `CODEOWNERS` file.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Added - Default Pull Request Reviewers via `CODEOWNERS` file.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.
