### PR TITLE
Added Additional Attributes to Podcast Block

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,28 +5,27 @@
 [![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![E2E Test](https://github.com/10up/simple-podcasting/actions/workflows/test-e2e.yml/badge.svg)](https://github.com/10up/simple-podcasting/actions/workflows/test-e2e.yml) [![Release Version](https://img.shields.io/github/release/10up/simple-podcasting.svg)](https://github.com/10up/simple-podcasting/releases/latest) ![WordPress tested up to version](https://img.shields.io/wordpress/plugin/tested/simple-podcasting?label=WordPress) [![GPLv2 License](https://img.shields.io/github/license/10up/simple-podcasting.svg)](https://github.com/10up/simple-podcasting/blob/develop/LICENSE.md)
 
 ## Table of Contents
-
--   [Overview](#overview)
--   [Requirements](#requirements)
--   [Installation](#installation)
--   [Create Podcast](#create-your-podcast)
--   [Add Content to Podcast](#add-content-to-your-podcast)
--   [Submit Podcast Feed to Apple Podcasts](#submit-your-podcast-feed-to-apple-podcasts)
--   [Control how many episodes are listed on the feed](#control-how-many-episodes-are-listed-on-the-feed)
--   [Customize RSS feed](#customize-rss-feed)
--   [Contributing](#contributing)
+* [Overview](#overview)
+* [Requirements](#requirements)
+* [Installation](#installation)
+* [Create Podcast](#create-your-podcast)
+* [Add Content to Podcast](#add-content-to-your-podcast)
+* [Submit Podcast Feed to Apple Podcasts](#submit-your-podcast-feed-to-apple-podcasts)
+* [Control how many episodes are listed on the feed](#control-how-many-episodes-are-listed-on-the-feed)
+* [Customize RSS feed](#customize-rss-feed)
+* [Contributing](#contributing)
 
 ## Overview
 
 Podcasting is a method to distribute audio messages through a feed to which listeners can subscribe. You can publish podcasts on your WordPress site and make them available for listeners in Apple Podcasts and through direct feed links for other podcasting apps by following these steps:
 
-![Screenshot of podcast block](.wordpress-org/screenshot-2.png 'Example of a podcast block in the new WordPress editor')
+![Screenshot of podcast block](.wordpress-org/screenshot-2.png "Example of a podcast block in the new WordPress editor")
 
 ## Requirements
 
--   PHP 7.0+
--   [WordPress](http://wordpress.org) 4.6+
--   RSS feeds must not be disabled
+* PHP 7.0+
+* [WordPress](http://wordpress.org) 4.6+
+* RSS feeds must not be disabled
 
 ## Installation
 
@@ -40,36 +39,36 @@ Podcasting is a method to distribute audio messages through a feed to which list
 From the WordPress Admin, go to Podcasts.
 To create a podcast, complete all of the "Add New Podcast" fields and click "Add New Podcast".
 
--   Name: this title appears in Apple Podcasts and any other podcast apps.
--   Slug: this is the URL-friendly version of the Name field.
--   Subtitle: the subtitle also appears in Apple Podcasts and any other podcast apps.
--   Artist / Author name: the artist or producer of the work.
--   Podcast email: a contact email address for your podcast.
--   Summary: Apple Podcasts displays this summary when browsing through podcasts.
--   Copyright / License information: copyright information viewable in Apple Podcasts or other podcast apps.
--   Mark as explicit: mark Yes if podcast contains adult language or adult themes.
--   Language: the main language spoken in the podcast.
--   Cover image: add the URL for the cover art to appear in Apple Podcasts and other podcast apps. Click "Select Image" and choose an image from the Media Library. Note that podcast cover images must be between 1400 x 1400 and 3000 x 3000 pixels in JPG or PNG formats to work on Apple Podcasts.
--   Keywords: add terms to help your podcast show up in search results on Apple Podcasts and other podcast apps.
--   Categories: these allow your podcast to show up for those browsing Apple Podcasts or other podcast apps by category.
+ * Name: this title appears in Apple Podcasts and any other podcast apps.
+ * Slug: this is the URL-friendly version of the Name field.
+ * Subtitle: the subtitle also appears in Apple Podcasts and any other podcast apps.
+ * Artist / Author name: the artist or producer of the work.
+ * Podcast email: a contact email address for your podcast.
+ * Summary: Apple Podcasts displays this summary when browsing through podcasts.
+ * Copyright / License information: copyright information viewable in Apple Podcasts or other podcast apps.
+ * Mark as explicit: mark Yes if podcast contains adult language or adult themes.
+ * Language: the main language spoken in the podcast.
+ * Cover image: add the URL for the cover art to appear in Apple Podcasts and other podcast apps. Click "Select Image" and choose an image from the Media Library. Note that podcast cover images must be between 1400 x 1400 and 3000 x 3000 pixels in JPG or PNG formats to work on Apple Podcasts.
+ * Keywords: add terms to help your podcast show up in search results on Apple Podcasts and other podcast apps.
+ * Categories: these allow your podcast to show up for those browsing Apple Podcasts or other podcast apps by category.
 
 Repeat for each podcast you would like to create.
 
 ## Add content to your podcast
 
--   Create a new post and assign it to one or more Podcasts using the panel labeled Podcasts.
--   Upload or embed an audio file into this post using any of the usual WordPress methods. If using the new block-based WordPress editor (sometimes referred to as Gutenberg), insert a Podcast block. Only one Podcast block can be inserted per post.
--   For more advanced settings, use the Podcasting meta box to mark explicit content or closed captioning available and to optionally specify one media item if the post if you have more than one in your post. In the block-based editor, these are the block settings that appear in the sidebar when the podcast block is selected.
+ * Create a new post and assign it to one or more Podcasts using the panel labeled Podcasts.
+ * Upload or embed an audio file into this post using any of the usual WordPress methods. If using the new block-based WordPress editor (sometimes referred to as Gutenberg), insert a Podcast block. Only one Podcast block can be inserted per post.
+ * For more advanced settings, use the Podcasting meta box to mark explicit content or closed captioning available, season number, episode number, episode type and to optionally specify one media item in the post if you have more than one in your post. In the block-based editor, these are the block settings that appear in the sidebar when the podcast block is selected.
 
 ## Submit your podcast feed to Apple Podcasts
 
--   Each podcast has a unique feed URL you can find on the Podcasts page. This is the URL you will submit to Apple.
--   Ensure you test feeds before submitting them, see https://help.apple.com/itc/podcasts_connect/#/itcac471c970.
--   Once the validator passes, submit your podcast. Podcasts submitted to Apple Podcasts do not become immediately available for subscription by others. They are submitted for review by Apple staff, see https://help.apple.com/itc/podcasts_connect/#/itcd88ea40b9
+* Each podcast has a unique feed URL you can find on the Podcasts page. This is the URL you will submit to Apple.
+* Ensure you test feeds before submitting them, see https://help.apple.com/itc/podcasts_connect/#/itcac471c970.
+* Once the validator passes, submit your podcast. Podcasts submitted to Apple Podcasts do not become immediately available for subscription by others. They are submitted for review by Apple staff, see https://help.apple.com/itc/podcasts_connect/#/itcd88ea40b9
 
-| Podcast setup                                                                        | Podcast in editor                                                                        | Podcast feed                                                                        |
-| ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| [![Podcast setup](.wordpress-org/screenshot-3.png)](.wordpress-org/screenshot-3.png) | [![Podcast in editor](.wordpress-org/screenshot-1.png)](.wordpress-org/screenshot-1.png) | [![Podcast feed](.wordpress-org/screenshot-4.png)](.wordpress-org/screenshot-4.png) |
+Podcast setup | Podcast in editor | Podcast feed
+------------- | ----------------- | ------------
+[![Podcast setup](.wordpress-org/screenshot-3.png)](.wordpress-org/screenshot-3.png) | [![Podcast in editor](.wordpress-org/screenshot-1.png)](.wordpress-org/screenshot-1.png) | [![Podcast feed](.wordpress-org/screenshot-4.png)](.wordpress-org/screenshot-4.png)
 
 ## Control how many episodes are listed on the feed
 
@@ -111,7 +110,7 @@ add_filter( 'simple_podcasting_feed_item', 'podcasting_feed_item_filter', 10, 3 
 
 ## Support Level
 
-**Active:** 10up is actively working on this, and we expect to continue work for the foreseeable future including keeping tested up to the most recent version of WordPress. Bug reports, feature requests, questions, and pull requests are welcome.
+**Active:** 10up is actively working on this, and we expect to continue work for the foreseeable future including keeping tested up to the most recent version of WordPress.  Bug reports, feature requests, questions, and pull requests are welcome.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Repeat for each podcast you would like to create.
 
 -   Create a new post and assign it to one or more Podcasts using the panel labeled Podcasts.
 -   Upload or embed an audio file into this post using any of the usual WordPress methods. If using the new block-based WordPress editor (sometimes referred to as Gutenberg), insert a Podcast block. Only one Podcast block can be inserted per post.
--   For more advanced settings, use the Podcasting meta box to mark explicit content or closed captioning available, season number, episode number, episode type and to optionally specify one media item in the post if you have more than one in your post. In the block-based editor, these are the block settings that appear in the sidebar when the podcast block is selected.
+-   For more advanced settings, use the Podcasting meta box to mark explicit content or closed captioning available and to optionally specify one media item if the post if you have more than one in your post. In the block-based editor, these are the block settings that appear in the sidebar when the podcast block is selected.
 
 ## Submit your podcast feed to Apple Podcasts
 

--- a/README.md
+++ b/README.md
@@ -5,27 +5,28 @@
 [![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![E2E Test](https://github.com/10up/simple-podcasting/actions/workflows/test-e2e.yml/badge.svg)](https://github.com/10up/simple-podcasting/actions/workflows/test-e2e.yml) [![Release Version](https://img.shields.io/github/release/10up/simple-podcasting.svg)](https://github.com/10up/simple-podcasting/releases/latest) ![WordPress tested up to version](https://img.shields.io/wordpress/plugin/tested/simple-podcasting?label=WordPress) [![GPLv2 License](https://img.shields.io/github/license/10up/simple-podcasting.svg)](https://github.com/10up/simple-podcasting/blob/develop/LICENSE.md)
 
 ## Table of Contents
-* [Overview](#overview)
-* [Requirements](#requirements)
-* [Installation](#installation)
-* [Create Podcast](#create-your-podcast)
-* [Add Content to Podcast](#add-content-to-your-podcast)
-* [Submit Podcast Feed to Apple Podcasts](#submit-your-podcast-feed-to-apple-podcasts)
-* [Control how many episodes are listed on the feed](#control-how-many-episodes-are-listed-on-the-feed)
-* [Customize RSS feed](#customize-rss-feed)
-* [Contributing](#contributing)
+
+-   [Overview](#overview)
+-   [Requirements](#requirements)
+-   [Installation](#installation)
+-   [Create Podcast](#create-your-podcast)
+-   [Add Content to Podcast](#add-content-to-your-podcast)
+-   [Submit Podcast Feed to Apple Podcasts](#submit-your-podcast-feed-to-apple-podcasts)
+-   [Control how many episodes are listed on the feed](#control-how-many-episodes-are-listed-on-the-feed)
+-   [Customize RSS feed](#customize-rss-feed)
+-   [Contributing](#contributing)
 
 ## Overview
 
 Podcasting is a method to distribute audio messages through a feed to which listeners can subscribe. You can publish podcasts on your WordPress site and make them available for listeners in Apple Podcasts and through direct feed links for other podcasting apps by following these steps:
 
-![Screenshot of podcast block](.wordpress-org/screenshot-2.png "Example of a podcast block in the new WordPress editor")
+![Screenshot of podcast block](.wordpress-org/screenshot-2.png 'Example of a podcast block in the new WordPress editor')
 
 ## Requirements
 
-* PHP 7.0+
-* [WordPress](http://wordpress.org) 4.6+
-* RSS feeds must not be disabled
+-   PHP 7.0+
+-   [WordPress](http://wordpress.org) 4.6+
+-   RSS feeds must not be disabled
 
 ## Installation
 
@@ -39,36 +40,36 @@ Podcasting is a method to distribute audio messages through a feed to which list
 From the WordPress Admin, go to Podcasts.
 To create a podcast, complete all of the "Add New Podcast" fields and click "Add New Podcast".
 
- * Name: this title appears in Apple Podcasts and any other podcast apps.
- * Slug: this is the URL-friendly version of the Name field.
- * Subtitle: the subtitle also appears in Apple Podcasts and any other podcast apps.
- * Artist / Author name: the artist or producer of the work.
- * Podcast email: a contact email address for your podcast.
- * Summary: Apple Podcasts displays this summary when browsing through podcasts.
- * Copyright / License information: copyright information viewable in Apple Podcasts or other podcast apps.
- * Mark as explicit: mark Yes if podcast contains adult language or adult themes.
- * Language: the main language spoken in the podcast.
- * Cover image: add the URL for the cover art to appear in Apple Podcasts and other podcast apps. Click "Select Image" and choose an image from the Media Library. Note that podcast cover images must be between 1400 x 1400 and 3000 x 3000 pixels in JPG or PNG formats to work on Apple Podcasts.
- * Keywords: add terms to help your podcast show up in search results on Apple Podcasts and other podcast apps.
- * Categories: these allow your podcast to show up for those browsing Apple Podcasts or other podcast apps by category.
+-   Name: this title appears in Apple Podcasts and any other podcast apps.
+-   Slug: this is the URL-friendly version of the Name field.
+-   Subtitle: the subtitle also appears in Apple Podcasts and any other podcast apps.
+-   Artist / Author name: the artist or producer of the work.
+-   Podcast email: a contact email address for your podcast.
+-   Summary: Apple Podcasts displays this summary when browsing through podcasts.
+-   Copyright / License information: copyright information viewable in Apple Podcasts or other podcast apps.
+-   Mark as explicit: mark Yes if podcast contains adult language or adult themes.
+-   Language: the main language spoken in the podcast.
+-   Cover image: add the URL for the cover art to appear in Apple Podcasts and other podcast apps. Click "Select Image" and choose an image from the Media Library. Note that podcast cover images must be between 1400 x 1400 and 3000 x 3000 pixels in JPG or PNG formats to work on Apple Podcasts.
+-   Keywords: add terms to help your podcast show up in search results on Apple Podcasts and other podcast apps.
+-   Categories: these allow your podcast to show up for those browsing Apple Podcasts or other podcast apps by category.
 
 Repeat for each podcast you would like to create.
 
 ## Add content to your podcast
 
- * Create a new post and assign it to one or more Podcasts using the panel labeled Podcasts.
- * Upload or embed an audio file into this post using any of the usual WordPress methods. If using the new block-based WordPress editor (sometimes referred to as Gutenberg), insert a Podcast block. Only one Podcast block can be inserted per post.
- * For more advanced settings, use the Podcasting meta box to mark explicit content or closed captioning available and to optionally specify one media item if the post if you have more than one in your post. In the block-based editor, these are the block settings that appear in the sidebar when the podcast block is selected.
+-   Create a new post and assign it to one or more Podcasts using the panel labeled Podcasts.
+-   Upload or embed an audio file into this post using any of the usual WordPress methods. If using the new block-based WordPress editor (sometimes referred to as Gutenberg), insert a Podcast block. Only one Podcast block can be inserted per post.
+-   For more advanced settings, use the Podcasting meta box to mark explicit content or closed captioning available, season number, episode number, episode type and to optionally specify one media item in the post if you have more than one in your post. In the block-based editor, these are the block settings that appear in the sidebar when the podcast block is selected.
 
 ## Submit your podcast feed to Apple Podcasts
 
-* Each podcast has a unique feed URL you can find on the Podcasts page. This is the URL you will submit to Apple.
-* Ensure you test feeds before submitting them, see https://help.apple.com/itc/podcasts_connect/#/itcac471c970.
-* Once the validator passes, submit your podcast. Podcasts submitted to Apple Podcasts do not become immediately available for subscription by others. They are submitted for review by Apple staff, see https://help.apple.com/itc/podcasts_connect/#/itcd88ea40b9
+-   Each podcast has a unique feed URL you can find on the Podcasts page. This is the URL you will submit to Apple.
+-   Ensure you test feeds before submitting them, see https://help.apple.com/itc/podcasts_connect/#/itcac471c970.
+-   Once the validator passes, submit your podcast. Podcasts submitted to Apple Podcasts do not become immediately available for subscription by others. They are submitted for review by Apple staff, see https://help.apple.com/itc/podcasts_connect/#/itcd88ea40b9
 
-Podcast setup | Podcast in editor | Podcast feed
-------------- | ----------------- | ------------
-[![Podcast setup](.wordpress-org/screenshot-3.png)](.wordpress-org/screenshot-3.png) | [![Podcast in editor](.wordpress-org/screenshot-1.png)](.wordpress-org/screenshot-1.png) | [![Podcast feed](.wordpress-org/screenshot-4.png)](.wordpress-org/screenshot-4.png)
+| Podcast setup                                                                        | Podcast in editor                                                                        | Podcast feed                                                                        |
+| ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [![Podcast setup](.wordpress-org/screenshot-3.png)](.wordpress-org/screenshot-3.png) | [![Podcast in editor](.wordpress-org/screenshot-1.png)](.wordpress-org/screenshot-1.png) | [![Podcast feed](.wordpress-org/screenshot-4.png)](.wordpress-org/screenshot-4.png) |
 
 ## Control how many episodes are listed on the feed
 
@@ -110,7 +111,7 @@ add_filter( 'simple_podcasting_feed_item', 'podcasting_feed_item_filter', 10, 3 
 
 ## Support Level
 
-**Active:** 10up is actively working on this, and we expect to continue work for the foreseeable future including keeping tested up to the most recent version of WordPress.  Bug reports, feature requests, questions, and pull requests are welcome.
+**Active:** 10up is actively working on this, and we expect to continue work for the foreseeable future including keeping tested up to the most recent version of WordPress. Bug reports, feature requests, questions, and pull requests are welcome.
 
 ## Changelog
 

--- a/assets/css/podcasting-editor-screen.css
+++ b/assets/css/podcasting-editor-screen.css
@@ -1,0 +1,4 @@
+.components-input-control,
+.components-base-control {
+	width: 100%;
+}

--- a/assets/js/blocks.js
+++ b/assets/js/blocks.js
@@ -75,12 +75,12 @@ export default registerBlockType(
 				meta: 'enclosure',
 			},
 			seasonNumber: {
-				type: 'number',
+				type: 'string',
 				source: 'meta',
 				meta: 'podcast_season_number',
 			},
 			episodeNumber: {
-				type: 'number',
+				type: 'string',
 				source: 'meta',
 				meta: 'podcast_episode_number',
 			},

--- a/assets/js/blocks.js
+++ b/assets/js/blocks.js
@@ -7,6 +7,7 @@ import { registerBlockType } from '@wordpress/blocks';
 // Split the Edit component out.
 import Edit from './edit';
 import transforms from './transforms';
+import '../css/podcasting-editor-screen.css';
 
 /**
  * Register example block
@@ -73,6 +74,21 @@ export default registerBlockType(
 				source: 'meta',
 				meta: 'enclosure',
 			},
+			seasonNumber: {
+				type: 'number',
+				source: 'meta',
+				meta: 'podcast_season_number',
+			},
+			episodeNumber: {
+				type: 'number',
+				source: 'meta',
+				meta: 'podcast_episode_number',
+			},
+			episodeType: {
+				type: 'string',
+				source: 'meta',
+				meta: 'podcast_episode_type',
+			}
 		},
 		transforms,
 

--- a/assets/js/edit.js
+++ b/assets/js/edit.js
@@ -15,8 +15,6 @@ const {
 	TextControl,
 	RadioControl,
 } = wp.components;
-const Spacer = wp.components.__experimentalSpacer;
-const NumberControl = wp.components.__experimentalNumberControl;
 const { Fragment } = wp.element;
 
 const { apiFetch } = wp;
@@ -46,8 +44,8 @@ class Edit extends Component {
 		const { caption, explicit } = attributes;
 		const duration = attributes.duration || '';
 		const captioned = attributes.captioned || '';
-		const seasonNumber = attributes.seasonNumber || 0;
-		const episodeNumber = attributes.episodeNumber || 0;
+		const seasonNumber = attributes.seasonNumber || '';
+		const episodeNumber = attributes.episodeNumber || '';
 		const episodeType = attributes.episodeType || '';
 		const { className, src } = this.state;
 
@@ -168,34 +166,25 @@ class Edit extends Component {
 							/>
 						</PanelRow>
 						<PanelRow>
-							<NumberControl
+							<TextControl
 								label={ __( 'Season Number', 'simple-podcasting' ) }
-								onChange={ seasonNumber => setAttributes( { seasonNumber } ) }
-								isShiftStepEnabled={ true }
-								shiftStep={ 1 }
 								value={ seasonNumber }
-								min={ 0 }
-								max={ 2000 }
+								onChange={ seasonNumber => setAttributes( { seasonNumber } ) }
 							/>
 						</PanelRow>
-						<Spacer marginBottom={6} />
 						<PanelRow>
-							<NumberControl
+							<TextControl
 								label={ __( 'Episode Number', 'simple-podcasting' ) }
-								onChange={ episodeNumber => setAttributes( { episodeNumber } ) }
-								isShiftStepEnabled={ true }
-								shiftStep={ 1 }
 								value={ episodeNumber }
-								min={ 0 }
-								max={ 2000 }
+								onChange={ episodeNumber => setAttributes( { episodeNumber } ) }
 							/>
 						</PanelRow>
-						<Spacer marginBottom={6} />
 						<PanelRow>
 							<RadioControl
 								label={ __( 'Episode Type', 'simple-podcasting' ) }
 								selected={ episodeType }
 								options={ [
+									{ label: __( 'None', 'simple-podcasting' ), value: 'none' },
 									{ label: __( 'Full', 'simple-podcasting' ), value: 'full' },
 									{ label: __( 'Trailer', 'simple-podcasting' ), value: 'trailer' },
 									{ label: __( 'Bonus', 'simple-podcasting' ), value: 'bonus' },

--- a/assets/js/edit.js
+++ b/assets/js/edit.js
@@ -13,7 +13,10 @@ const {
 	PanelRow,
 	SelectControl,
 	TextControl,
+	RadioControl,
 } = wp.components;
+const Spacer = wp.components.__experimentalSpacer;
+const NumberControl = wp.components.__experimentalNumberControl;
 const { Fragment } = wp.element;
 
 const { apiFetch } = wp;
@@ -43,6 +46,9 @@ class Edit extends Component {
 		const { caption, explicit } = attributes;
 		const duration = attributes.duration || '';
 		const captioned = attributes.captioned || '';
+		const seasonNumber = attributes.seasonNumber || 0;
+		const episodeNumber = attributes.episodeNumber || 0;
+		const episodeType = attributes.episodeType || '';
 		const { className, src } = this.state;
 
 		const onSelectAttachment = ( attachment ) => {
@@ -159,6 +165,42 @@ class Edit extends Component {
 								label={ __( 'Length (MM:SS)', 'simple-podcasting' ) }
 								value={ duration }
 								onChange={ duration => setAttributes( { duration } ) }
+							/>
+						</PanelRow>
+						<PanelRow>
+							<NumberControl
+								label={ __( 'Season Number', 'simple-podcasting' ) }
+								onChange={ seasonNumber => setAttributes( { seasonNumber } ) }
+								isShiftStepEnabled={ true }
+								shiftStep={ 1 }
+								value={ seasonNumber }
+								min={ 0 }
+								max={ 2000 }
+							/>
+						</PanelRow>
+						<Spacer marginBottom={6} />
+						<PanelRow>
+							<NumberControl
+								label={ __( 'Episode Number', 'simple-podcasting' ) }
+								onChange={ episodeNumber => setAttributes( { episodeNumber } ) }
+								isShiftStepEnabled={ true }
+								shiftStep={ 1 }
+								value={ episodeNumber }
+								min={ 0 }
+								max={ 2000 }
+							/>
+						</PanelRow>
+						<Spacer marginBottom={6} />
+						<PanelRow>
+							<RadioControl
+								label={ __( 'Episode Type', 'simple-podcasting' ) }
+								selected={ episodeType }
+								options={ [
+									{ label: __( 'Full', 'simple-podcasting' ), value: 'full' },
+									{ label: __( 'Trailer', 'simple-podcasting' ), value: 'trailer' },
+									{ label: __( 'Bonus', 'simple-podcasting' ), value: 'bonus' },
+								] }
+								onChange={ episodeType => setAttributes( { episodeType } ) }
 							/>
 						</PanelRow>
 					</PanelBody>

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -20,10 +20,19 @@ function init() {
 		true
 	);
 
+	wp_register_style(
+		'podcasting-block-editor',
+		PODCASTING_URL . 'dist/blocks.css',
+		array(),
+		$block_asset['version'],
+		'all'
+	);
+
 	register_block_type(
 		'podcasting/podcast',
 		array(
 			'editor_script' => 'podcasting-block-editor',
+			'editor_style'  => 'podcasting-block-editor',
 		)
 	);
 }
@@ -41,6 +50,9 @@ function register_js_strings() {
 	__( 'Podcast Settings', 'simple-podcasting' );
 	__( 'Length (MM:SS)', 'simple-podcasting' );
 	__( 'a podcast episode', 'simple-podcasting' );
+	__( 'Season Number', 'simple-podcasting' );
+	__( 'Episode Number', 'simple-podcasting' );
+	__( 'Episode Type', 'simple-podcasting' );
 }
 add_action( 'init', __NAMESPACE__ . '\register_js_strings' );
 

--- a/includes/customize-feed.php
+++ b/includes/customize-feed.php
@@ -172,14 +172,17 @@ function feed_item() {
 	}
 
 	$feed_item = array(
-		'author'    => get_option( 'podcasting_talent_name' ),
-		'explicit'  => get_post_meta( $post->ID, 'podcast_explicit', true ),
-		'captioned' => get_post_meta( $post->ID, 'podcast_captioned', true ),
-		'keywords'  => '',
-		'image'     => '',
-		'summary'   => '',
-		'subtitle'  => '',
-		'duration'  => get_post_meta( $post->ID, 'podcast_duration', true ),
+		'author'      => get_option( 'podcasting_talent_name' ),
+		'explicit'    => get_post_meta( $post->ID, 'podcast_explicit', true ),
+		'captioned'   => get_post_meta( $post->ID, 'podcast_captioned', true ),
+		'keywords'    => '',
+		'image'       => '',
+		'summary'     => '',
+		'subtitle'    => '',
+		'duration'    => get_post_meta( $post->ID, 'podcast_duration', true ),
+		'season'      => get_post_meta( $post->ID, 'podcast_season_number', true ),
+		'episode'     => get_post_meta( $post->ID, 'podcast_episode_number', true ),
+		'episodeType' => get_post_meta( $post->ID, 'podcast_episode_type', true ),
 	);
 
 	if ( empty( $feed_item['author'] ) ) {
@@ -221,14 +224,17 @@ function feed_item() {
 	 * @param array $feed_item {
 	 *     Item data to filter.
 	 *
-	 *     @type string $author    Podcast author.
-	 *     @type string $explicit  Explicit content (yes|no|clean).
-	 *     @type string $captioned Closed Captioned ("1"|"0"). Optional.
-	 *     @type string $keywords  Episode keywords. Optional.
-	 *     @type string $image     Episode image. Optional.
-	 *     @type string $summary   Episode summary.
-	 *     @type string $subtitle  Episode subtitle.
-	 *     @type string $duration  Episode duration (HH:MM). Optional.
+	 *     @type string $author      Podcast author.
+	 *     @type string $explicit    Explicit content (yes|no|clean).
+	 *     @type string $captioned   Closed Captioned ("1"|"0"). Optional.
+	 *     @type string $keywords    Episode keywords. Optional.
+	 *     @type string $image       Episode image. Optional.
+	 *     @type string $summary     Episode summary.
+	 *     @type string $subtitle    Episode subtitle.
+	 *     @type string $duration    Episode duration (HH:MM). Optional.
+	 *     @type number $season      Season number Optional.
+	 *     @type number $episode     Episode number Optional.
+	 *     @type string $episodeType Episode type Optional.
 	 * }
 	 * @param int $post->ID Podcast episode post ID.
 	 * @param int $term->term_id Podcast term ID.
@@ -257,6 +263,15 @@ function feed_item() {
 	echo '<itunes:subtitle>' . esc_html( $feed_item['subtitle'] ) . "</itunes:subtitle>\n";
 	if ( ! empty( $feed_item['duration'] ) ) {
 		echo '<itunes:duration>' . esc_html( $feed_item['duration'] ) . "</itunes:duration>\n";
+	}
+	if ( ! empty( $feed_item['season'] ) ) {
+		echo '<itunes:season>' . esc_html( absint( $feed_item['season'] ) ) . "</itunes:season>\n";
+	}
+	if ( ! empty( $feed_item['episode'] ) ) {
+		echo '<itunes:episode>' . esc_html( absint( $feed_item['episode'] ) ) . "</itunes:episode>\n";
+	}
+	if ( ! empty( $feed_item['episodeType'] ) ) {
+		echo '<itunes:episodeType>' . esc_html( $feed_item['episodeType'] ) . "</itunes:episodeType>\n";
 	}
 }
 add_action( 'rss2_item', __NAMESPACE__ . '\feed_item' );

--- a/includes/customize-feed.php
+++ b/includes/customize-feed.php
@@ -180,8 +180,8 @@ function feed_item() {
 		'summary'     => '',
 		'subtitle'    => '',
 		'duration'    => get_post_meta( $post->ID, 'podcast_duration', true ),
-		'season'      => (int) get_post_meta( $post->ID, 'podcast_season_number', true ),
-		'episode'     => (int) get_post_meta( $post->ID, 'podcast_episode_number', true ),
+		'season'      => get_post_meta( $post->ID, 'podcast_season_number', true ),
+		'episode'     => get_post_meta( $post->ID, 'podcast_episode_number', true ),
 		'episodeType' => get_post_meta( $post->ID, 'podcast_episode_type', true ),
 	);
 
@@ -232,8 +232,8 @@ function feed_item() {
 	 *     @type string $summary     Episode summary.
 	 *     @type string $subtitle    Episode subtitle.
 	 *     @type string $duration    Episode duration (HH:MM). Optional.
-	 *     @type number $season      Season number Optional.
-	 *     @type number $episode     Episode number Optional.
+	 *     @type string $season      Season number Optional.
+	 *     @type string $episode     Episode number Optional.
 	 *     @type string $episodeType Episode type Optional.
 	 * }
 	 * @param int $post->ID Podcast episode post ID.
@@ -270,7 +270,7 @@ function feed_item() {
 	if ( ! empty( $feed_item['episode'] ) ) {
 		echo '<itunes:episode>' . esc_html( $feed_item['episode'] ) . "</itunes:episode>\n";
 	}
-	if ( ! empty( $feed_item['episodeType'] ) ) {
+	if ( ! empty( $feed_item['episodeType'] ) && 'none' !== $feed_item['episodeType'] ) {
 		echo '<itunes:episodeType>' . esc_html( $feed_item['episodeType'] ) . "</itunes:episodeType>\n";
 	}
 }

--- a/includes/customize-feed.php
+++ b/includes/customize-feed.php
@@ -180,8 +180,8 @@ function feed_item() {
 		'summary'     => '',
 		'subtitle'    => '',
 		'duration'    => get_post_meta( $post->ID, 'podcast_duration', true ),
-		'season'      => get_post_meta( $post->ID, 'podcast_season_number', true ),
-		'episode'     => get_post_meta( $post->ID, 'podcast_episode_number', true ),
+		'season'      => (int) get_post_meta( $post->ID, 'podcast_season_number', true ),
+		'episode'     => (int) get_post_meta( $post->ID, 'podcast_episode_number', true ),
 		'episodeType' => get_post_meta( $post->ID, 'podcast_episode_type', true ),
 	);
 
@@ -265,10 +265,10 @@ function feed_item() {
 		echo '<itunes:duration>' . esc_html( $feed_item['duration'] ) . "</itunes:duration>\n";
 	}
 	if ( ! empty( $feed_item['season'] ) ) {
-		echo '<itunes:season>' . esc_html( absint( $feed_item['season'] ) ) . "</itunes:season>\n";
+		echo '<itunes:season>' . esc_html( $feed_item['season'] ) . "</itunes:season>\n";
 	}
 	if ( ! empty( $feed_item['episode'] ) ) {
-		echo '<itunes:episode>' . esc_html( absint( $feed_item['episode'] ) ) . "</itunes:episode>\n";
+		echo '<itunes:episode>' . esc_html( $feed_item['episode'] ) . "</itunes:episode>\n";
 	}
 	if ( ! empty( $feed_item['episodeType'] ) ) {
 		echo '<itunes:episodeType>' . esc_html( $feed_item['episodeType'] ) . "</itunes:episodeType>\n";

--- a/includes/datatypes.php
+++ b/includes/datatypes.php
@@ -80,6 +80,36 @@ function register_meta() {
 			'single'       => true,
 		)
 	);
+
+	\register_meta(
+		'post',
+		'podcast_season_number',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'number',
+			'single'       => true,
+		)
+	);
+
+	\register_meta(
+		'post',
+		'podcast_episode_number',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'number',
+			'single'       => true,
+		)
+	);
+
+	\register_meta(
+		'post',
+		'podcast_episode_type',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'string',
+			'single'       => true,
+		)
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_meta' );
 

--- a/includes/datatypes.php
+++ b/includes/datatypes.php
@@ -86,7 +86,7 @@ function register_meta() {
 		'podcast_season_number',
 		array(
 			'show_in_rest' => true,
-			'type'         => 'number',
+			'type'         => 'string',
 			'single'       => true,
 		)
 	);
@@ -96,7 +96,7 @@ function register_meta() {
 		'podcast_episode_number',
 		array(
 			'show_in_rest' => true,
-			'type'         => 'number',
+			'type'         => 'string',
 			'single'       => true,
 		)
 	);

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -77,5 +77,8 @@ function delete_all_podcast_meta( $post_id ) {
 		delete_post_meta( $post_id, 'podcast_captioned' );
 		delete_post_meta( $post_id, 'podcast_explicit' );
 		delete_post_meta( $post_id, 'enclosure' );
+		delete_post_meta( $post_id, 'podcast_season_number' );
+		delete_post_meta( $post_id, 'podcast_episode_number' );
+		delete_post_meta( $post_id, 'podcast_episode_type' );
 	}
 }

--- a/includes/post-meta-box.php
+++ b/includes/post-meta-box.php
@@ -60,18 +60,20 @@ function meta_box_html( $post ) {
 	<p>
 		<label for="podcast_season_number">
 			<?php esc_html_e( 'Season Number', 'simple-podcasting' ); ?>
-			<input type="number" min="0" max="2000" step="1" id="podcast_season_number" name="podcast_season_number" value="<?php echo esc_attr( $season_number ); ?>" />
+			<input type="text" id="podcast_season_number" name="podcast_season_number" value="<?php echo esc_attr( $season_number ); ?>" />
 		</label>
 	</p>
 	<p>
 		<label for="podcast_episode_number">
 			<?php esc_html_e( 'Episode Number', 'simple-podcasting' ); ?>
-			<input type="number" min="0" max="2000" step="1" id="podcast_episode_number" name="podcast_episode_number" value="<?php echo esc_attr( $episode_number ); ?>" />
+			<input type="text" id="podcast_episode_number" name="podcast_episode_number" value="<?php echo esc_attr( $episode_number ); ?>" />
 		</label>
 	</p>
 	<div style="display: flex; align-items: center;">
 		<p style="margin-right: 5px;"><?php esc_html_e( 'Episode Type', 'simple-podcasting' ); ?></p>
 		<p>
+			<input type="radio" id="none" name="podcast_episode_type" value="none" <?php echo isset( $episode_type ) && 'none' === $episode_type ? 'checked' : ''; ?>>
+			<label for="none"><?php esc_html_e( 'None', 'simple-podcasting' ); ?></label><br>
 			<input type="radio" id="full" name="podcast_episode_type" value="full" <?php echo isset( $episode_type ) && 'full' === $episode_type ? 'checked' : ''; ?>>
 			<label for="full"><?php esc_html_e( 'Full', 'simple-podcasting' ); ?></label><br>
 			<input type="radio" id="trailer" name="podcast_episode_type" value="trailer" <?php echo isset( $episode_type ) && 'trailer' === $episode_type ? 'checked' : ''; ?>>
@@ -115,9 +117,9 @@ function save_meta_box( $post_id ) {
 	$url               = false;
 	$podcast_captioned = 0;
 	$podcast_explicit  = 'no';
-	$season_number     = isset( $_post['podcast_season_number'] ) ? absint( $_post['podcast_season_number'] ) : 0;
-	$episode_number    = isset( $_post['podcast_episode_number'] ) ? absint( $_post['podcast_episode_number'] ) : 0;
-	$episode_type      = isset( $_post['podcast_episode_type'] ) && in_array( $_post['podcast_episode_type'], array( 'full', 'trailer', 'bonus' ), true ) ? sanitize_text_field( $_post['podcast_episode_type'] ) : '';
+	$season_number     = isset( $_post['podcast_season_number'] ) ? sanitize_text_field( $_post['podcast_season_number'] ) : '';
+	$episode_number    = isset( $_post['podcast_episode_number'] ) ? sanitize_text_field( $_post['podcast_episode_number'] ) : '';
+	$episode_type      = isset( $_post['podcast_episode_type'] ) && in_array( $_post['podcast_episode_type'], array( 'none', 'full', 'trailer', 'bonus' ), true ) ? sanitize_text_field( $_post['podcast_episode_type'] ) : '';
 
 	if ( isset( $_post['podcast_closed_captioned'] ) && 'on' === $_post['podcast_closed_captioned'] ) {
 		$podcast_captioned = 1;

--- a/includes/post-meta-box.php
+++ b/includes/post-meta-box.php
@@ -34,6 +34,9 @@ function meta_box_html( $post ) {
 	$podcast_url       = get_post_meta( $post->ID, 'podcast_url', true );
 	$podcast_explicit  = get_post_meta( $post->ID, 'podcast_explicit', true );
 	$podcast_captioned = get_post_meta( $post->ID, 'podcast_captioned', true );
+	$season_number     = get_post_meta( $post->ID, 'podcast_season_number', true );
+	$episode_number    = get_post_meta( $post->ID, 'podcast_episode_number', true );
+	$episode_type      = get_post_meta( $post->ID, 'podcast_episode_type', true );
 
 	wp_nonce_field( plugin_basename( __FILE__ ), 'simple-podcasting' );
 	?>
@@ -54,7 +57,28 @@ function meta_box_html( $post ) {
 			</select>
 		</label>
 	</p>
-
+	<p>
+		<label for="podcast_season_number">
+			<?php esc_html_e( 'Season Number', 'simple-podcasting' ); ?>
+			<input type="number" min="0" max="2000" step="1" id="podcast_season_number" name="podcast_season_number" value="<?php echo esc_attr( $season_number ); ?>" />
+		</label>
+	</p>
+	<p>
+		<label for="podcast_episode_number">
+			<?php esc_html_e( 'Episode Number', 'simple-podcasting' ); ?>
+			<input type="number" min="0" max="2000" step="1" id="podcast_episode_number" name="podcast_episode_number" value="<?php echo esc_attr( $episode_number ); ?>" />
+		</label>
+	</p>
+	<p>
+		<label for="podcast_episode_type">
+			<?php esc_html_e( 'Episode Type', 'simple-podcasting' ); ?>
+			<select id="podcast_episode_type" name="podcast_episode_type">
+				<option value="full"<?php selected( $episode_type, 'full' ); ?>><?php esc_html_e( 'Full', 'simple-podcasting' ); ?></option>
+				<option value="trailer"<?php selected( $episode_type, 'trailer' ); ?>><?php esc_html_e( 'Trailer', 'simple-podcasting' ); ?></option>
+				<option value="bonus"<?php selected( $episode_type, 'bonus' ); ?>><?php esc_html_e( 'Bonus', 'simple-podcasting' ); ?></option>
+			</select>
+		</label>
+	</p>
 	<p>
 		<label for="podcasting-enclosure-url"><?php esc_html_e( 'Enclosure', 'simple-podcasting' ); ?></label>
 		<input type="text" id="podcasting-enclosure-url" name="podcast_enclosure_url" value="<?php echo esc_url( $podcast_url ); ?>" size="35" />
@@ -90,6 +114,9 @@ function save_meta_box( $post_id ) {
 	$url               = false;
 	$podcast_captioned = 0;
 	$podcast_explicit  = 'no';
+	$season_number     = isset( $_post['podcast_season_number'] ) ? absint( $_post['podcast_season_number'] ) : 0;
+	$episode_number    = isset( $_post['podcast_episode_number'] ) ? absint( $_post['podcast_episode_number'] ) : 0;
+	$episode_type      = isset( $_post['podcast_episode_type'] ) && in_array( $_post['podcast_episode_type'], array( 'full', 'trailer', 'bonus' ), true ) ? sanitize_text_field( $_post['podcast_episode_type'] ) : '';
 
 	if ( isset( $_post['podcast_closed_captioned'] ) && 'on' === $_post['podcast_closed_captioned'] ) {
 		$podcast_captioned = 1;
@@ -141,6 +168,9 @@ function save_meta_box( $post_id ) {
 
 	update_post_meta( $post_id, 'podcast_explicit', $podcast_explicit );
 	update_post_meta( $post_id, 'podcast_captioned', $podcast_captioned );
+	update_post_meta( $post_id, 'podcast_season_number', $season_number );
+	update_post_meta( $post_id, 'podcast_episode_number', $episode_number );
+	update_post_meta( $post_id, 'podcast_episode_type', $episode_type );
 
 }
 add_action( 'save_post_post', __NAMESPACE__ . '\save_meta_box' );

--- a/includes/post-meta-box.php
+++ b/includes/post-meta-box.php
@@ -69,16 +69,17 @@ function meta_box_html( $post ) {
 			<input type="number" min="0" max="2000" step="1" id="podcast_episode_number" name="podcast_episode_number" value="<?php echo esc_attr( $episode_number ); ?>" />
 		</label>
 	</p>
-	<p>
-		<label for="podcast_episode_type">
-			<?php esc_html_e( 'Episode Type', 'simple-podcasting' ); ?>
-			<select id="podcast_episode_type" name="podcast_episode_type">
-				<option value="full"<?php selected( $episode_type, 'full' ); ?>><?php esc_html_e( 'Full', 'simple-podcasting' ); ?></option>
-				<option value="trailer"<?php selected( $episode_type, 'trailer' ); ?>><?php esc_html_e( 'Trailer', 'simple-podcasting' ); ?></option>
-				<option value="bonus"<?php selected( $episode_type, 'bonus' ); ?>><?php esc_html_e( 'Bonus', 'simple-podcasting' ); ?></option>
-			</select>
-		</label>
-	</p>
+	<div style="display: flex; align-items: center;">
+		<p style="margin-right: 5px;"><?php esc_html_e( 'Episode Type', 'simple-podcasting' ); ?></p>
+		<p>
+			<input type="radio" id="full" name="podcast_episode_type" value="full" <?php echo isset( $episode_type ) && 'full' === $episode_type ? 'checked' : ''; ?>>
+			<label for="full"><?php esc_html_e( 'Full', 'simple-podcasting' ); ?></label><br>
+			<input type="radio" id="trailer" name="podcast_episode_type" value="trailer" <?php echo isset( $episode_type ) && 'trailer' === $episode_type ? 'checked' : ''; ?>>
+			<label for="trailer"><?php esc_html_e( 'Trailer', 'simple-podcasting' ); ?></label><br>
+			<input type="radio" id="bonus" name="podcast_episode_type" value="bonus" <?php echo isset( $episode_type ) && 'bonus' === $episode_type ? 'checked' : ''; ?>>
+			<label for="bonus"><?php esc_html_e( 'Bonus', 'simple-podcasting' ); ?></label>
+		</p>
+	</div>
 	<p>
 		<label for="podcasting-enclosure-url"><?php esc_html_e( 'Enclosure', 'simple-podcasting' ); ?></label>
 		<input type="text" id="podcasting-enclosure-url" name="podcast_enclosure_url" value="<?php echo esc_url( $podcast_url ); ?>" size="35" />

--- a/tests/unit/test-blocks.php
+++ b/tests/unit/test-blocks.php
@@ -41,6 +41,20 @@ class BlockTests extends TestCase {
 		);
 
 		\WP_Mock::userFunction(
+			'wp_register_style',
+			array(
+				'times' => 1,
+				'args'  => array(
+					'podcasting-block-editor',
+					PODCASTING_URL . 'dist/blocks.css',
+					array(),
+					$block_asset['version'],
+					'all',
+				),
+			)
+		);
+
+		\WP_Mock::userFunction(
 			'register_block_type',
 			array(
 				'times' => 1,
@@ -48,6 +62,7 @@ class BlockTests extends TestCase {
 					'podcasting/podcast',
 					array(
 						'editor_script' => 'podcasting-block-editor',
+						'editor_style'  => 'podcasting-block-editor',
 					),
 				),
 			)
@@ -59,7 +74,7 @@ class BlockTests extends TestCase {
 	}
 
 	public function test_register_js_strings() {
-		\WP_Mock::userFunction( '__', array( 'times' => 4 ) );
+		\WP_Mock::userFunction( '__', array( 'times' => 7 ) );
 
 		$result = tenup_podcasting\block\register_js_strings();
 		$this->assertNull( $result );
@@ -109,11 +124,11 @@ class BlockTests extends TestCase {
 				'metadata_exists' => false,
 				'expected'        => null,
 			),
-			'Delete 6 metas'                      => array(
+			'Delete 10 metas'                      => array(
 				'creating'        => false,
 				'has_block'       => false,
 				'metadata_exists' => true,
-				'expected'        => array( 'podcast_url', 'podcast_filesize', 'podcast_duration', 'podcast_mime', 'podcast_captioned', 'podcast_explicit', 'enclosure' ),
+				'expected'        => array( 'podcast_url', 'podcast_filesize', 'podcast_duration', 'podcast_mime', 'podcast_captioned', 'podcast_explicit', 'enclosure', 'podcast_season_number', 'podcast_episode_number', 'podcast_episode_type' ),
 			),
 		);
 	}

--- a/tests/unit/test-customize-feed.php
+++ b/tests/unit/test-customize-feed.php
@@ -201,8 +201,8 @@ class CustomizeFeedTests extends TestCase {
 					'podcast_explicit'       => '',
 					'podcast_captioned'      => '',
 					'podcast_duration'       => '',
-					'podcast_season_number'  => 0,
-					'podcast_episode_number' => 0,
+					'podcast_season_number'  => '',
+					'podcast_episode_number' => '',
 					'podcast_episode_type'   => '',
 				),
 				'term_meta'     => array(
@@ -235,8 +235,8 @@ class CustomizeFeedTests extends TestCase {
 					'podcast_explicit'       => 'yes',
 					'podcast_captioned'      => '1',
 					'podcast_duration'       => '1:23',
-					'podcast_season_number'  => 2,
-					'podcast_episode_number' => 4,
+					'podcast_season_number'  => '2',
+					'podcast_episode_number' => '4',
 					'podcast_episode_type'   => 'full',
 				),
 				'term_meta'     => array(

--- a/tests/unit/test-customize-feed.php
+++ b/tests/unit/test-customize-feed.php
@@ -198,9 +198,12 @@ class CustomizeFeedTests extends TestCase {
 				'term'          => (object) array( 'term_id' => 2 ),
 				'post_author'   => 'Post Author',
 				'post_meta'     => array(
-					'podcast_explicit'  => '',
-					'podcast_captioned' => '',
-					'podcast_duration'  => '',
+					'podcast_explicit'       => '',
+					'podcast_captioned'      => '',
+					'podcast_duration'       => '',
+					'podcast_season_number'  => 0,
+					'podcast_episode_number' => 0,
+					'podcast_episode_type'   => '',
 				),
 				'term_meta'     => array(
 					'podcasting_explicit' => '',
@@ -215,6 +218,9 @@ class CustomizeFeedTests extends TestCase {
 					'Post excerpt as summary'       => '/<itunes:summary>Post Excerpt<\/itunes:summary>/',
 					'Post excerpt as subtitle'      => '/<itunes:subtitle>Post Excerpt<\/itunes:subtitle>/',
 					'Duration is empty'             => '/^((?!<itunes:duration>).)*$/s',
+					'Doesnt contain season'         => '/^((?!season).)*$/s',
+					'Doesnt contain episode'        => '/^((?!episode).)*$/s',
+					'Doesnt contain episode type'   => '/^((?!episodeType).)*$/s',
 				),
 			),
 			'Mixed Test 2'                => array(
@@ -226,9 +232,12 @@ class CustomizeFeedTests extends TestCase {
 				'term'          => (object) array( 'term_id' => 2 ),
 				'post_author'   => 'Post Author',
 				'post_meta'     => array(
-					'podcast_explicit'  => 'yes',
-					'podcast_captioned' => '1',
-					'podcast_duration'  => '1:23',
+					'podcast_explicit'       => 'yes',
+					'podcast_captioned'      => '1',
+					'podcast_duration'       => '1:23',
+					'podcast_season_number'  => 2,
+					'podcast_episode_number' => 4,
+					'podcast_episode_type'   => 'full',
 				),
 				'term_meta'     => array(
 					'podcasting_explicit' => '',
@@ -243,6 +252,9 @@ class CustomizeFeedTests extends TestCase {
 					'Long Summary'             => '/<itunes:summary>Very Long Post Excerpt Very Long Post Excerpt Very Long Post Excerpt Very Long Post Excerpt<\/itunes:summary>/',
 					'Short Subtitle'           => '/<itunes:subtitle>Short Excerpt<\/itunes:subtitle>/',
 					'Duration'                 => '/<itunes:duration>1:23<\/itunes:duration>/',
+					'Season'                   => '/<itunes:season>2<\/itunes:season>/',
+					'Episode'                  => '/<itunes:episode>4<\/itunes:episode>/',
+					'Episode type'             => '/<itunes:episodeType>full<\/itunes:episodeType>/',
 				),
 			),
 			'Mixed Test 3'                => array(

--- a/tests/unit/test-helpers.php
+++ b/tests/unit/test-helpers.php
@@ -30,7 +30,7 @@ class HelpersTests extends TestCase {
 
 		$this->assertNull(tenup_podcasting\helpers\delete_all_podcast_meta( 42 ));
 
-		$meta_keys = array('podcast_url', 'podcast_filesize', 'podcast_duration', 'podcast_mime', 'podcast_captioned', 'podcast_explicit', 'enclosure');
+		$meta_keys = array( 'podcast_url', 'podcast_filesize', 'podcast_duration', 'podcast_mime', 'podcast_captioned', 'podcast_explicit', 'enclosure', 'podcast_season_number', 'podcast_episode_number', 'podcast_episode_type' );
 		foreach ( $meta_keys as $meta_key ) {
 			\WP_Mock::userFunction( 'delete_post_meta' )->with( 42, $meta_key );
 		}


### PR DESCRIPTION
### Requirements
Reference is [here](https://github.com/10up/simple-podcasting/issues/172)

All modern podcast players are now expecting details of Podcast Season, Episode number and the type of episode (Trailer, full etc.). It will be great to have these added as custom fields with each episode. These correspond respectively to itunes:season, itunes:episode and itunes:episodeType respectively for the parent.

### Description of the Change

Additional attributes 'Season Number', 'Episode Number' and 'Episode Type' has been added in the block editor for Podcast block and the fallback is also added as post meta for classic editor. These attributes will get added in the podcast feed for each item within the channel.

Below are some of the screenshots for better understanding:

In Gutenberg sidebar:
<img width="278" alt="Screenshot 2022-06-14 at 8 01 54 PM" src="https://user-images.githubusercontent.com/45451844/173631053-70ca8b8e-cd10-40d2-8585-f9f7d4409fd8.png">

In Classic editor:
<img width="523" alt="Screenshot 2022-06-14 at 8 02 20 PM" src="https://user-images.githubusercontent.com/45451844/173631100-f49797bb-fbee-48e0-a1d0-41ba0a1c8ca6.png">

In the Feed xml:
<img width="407" alt="Screenshot 2022-06-14 at 7 36 24 PM" src="https://user-images.githubusercontent.com/45451844/173631151-a35cab0b-dbad-44d7-ae0d-5526d02cb26c.png">

### Alternate Designs
For the **Season Number** and **Episode Number** field, earlier we used number input type; however, these are still experimental in WP Core and has compatibility issues with the older versions so I changed the input type to simple text field for better compatibility and to clear out user confusion when emptying the fields with no values.

We could use select input type for the **Episode Type** field values; however, since this will be only one value at a time so radio input field seemed the proper candidate for the design.

### Possible Drawbacks

None so far.

### Verification Process

To verify the process, I created a new episode and added the Podcast block, the new attribute fields are displayed in the Inspector control sidebar for Gutenberg editor and below the content for classic editor interface. Adding or changing the values get saved as post meta which are then retrieved and used in the xml markup of the podcast feed for each episode.
I checked for empty values and if no values were provided the markup wouldn't contain these meta in the feed.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

> Added - Season Number attribute to Podcast block
> Added - Episode Number attribute to Podcast block
> Added - Episode Type attribute to Podcast block

### Credits

Props @zamanq, @dchucks
