### PR TITLE
Corrected Language Value in the Feed

### DIFF
--- a/includes/customize-feed.php
+++ b/includes/customize-feed.php
@@ -73,6 +73,7 @@ function bloginfo_rss_lang( $output, $requested ) {
 	if ( 'language' === $requested ) {
 		$lang = get_term_meta( $term->term_id, 'podcasting_language', true );
 		if ( $lang ) {
+			$lang   = str_replace( '_', '-', $lang );
 			$output = $lang;
 		}
 	}


### PR DESCRIPTION

### Requirements

The issue is described [here](https://github.com/10up/simple-podcasting/issues/174)

IMHO the value for the "Language" tag in the feed should be in format - e.g. en-US, but presently an underscore (_) is being used instead of a hyphen (-), e.g. hi_IN while it should be hi-IN instead. I have seen some platforms (like Jio Saavn) unable to read the language due to this bug and default to English.

### Description of the Change

Corrected the language value appearing in the podcast feed. Before the fix, the language code contained underscore('_') instead of dash('-') which introduced bugs in some platforms.

### Possible Drawbacks

None so far.

### Verification Process

After fixing the issue I created several new podcasts and selected different languages for those. The language code is working fine in the feed and appears correctly.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

> Fixed - Incorrect Language value in the Feed

### Credits

Props @zamanq @dchucks
