### PR TITLE
Fix mime type for enclosure saved from classic editor

### DIFF
--- a/includes/post-meta-box.php
+++ b/includes/post-meta-box.php
@@ -160,10 +160,10 @@ function save_meta_box( $post_id ) {
 			update_post_meta( $post_id, 'podcast_url', $podcast_meta['url'] );
 			update_post_meta( $post_id, 'podcast_filesize', $podcast_meta['filesize'] );
 			update_post_meta( $post_id, 'podcast_duration', $podcast_meta['duration'] );
-			update_post_meta( $post_id, 'podcast_mime', $podcast_meta['podcast_mime'] );
+			update_post_meta( $post_id, 'podcast_mime', $podcast_meta['mime'] );
 
 			// Add enclosure meta data
-			$enclosure = $podcast_meta['url'] . "\n" . $podcast_meta['filesize'] . "\n" . $podcast_meta['podcast_mime'];
+			$enclosure = $podcast_meta['url'] . "\n" . $podcast_meta['filesize'] . "\n" . $podcast_meta['mime'];
 
 			update_post_meta( $post_id, 'enclosure', $enclosure );
 		}

--- a/tests/unit/test-helpers.php
+++ b/tests/unit/test-helpers.php
@@ -24,17 +24,82 @@ class HelpersTests extends TestCase {
 	}
 
 	public function test_delete_all_podcast_meta() {
-		\WP_Mock::userFunction( 'metadata_exists', array(
-			'return_in_order' => array( false, true )
-		) );
+		\WP_Mock::userFunction(
+			'metadata_exists',
+			array(
+				'return_in_order' => array( false, true ),
+			)
+		);
 
-		$this->assertNull(tenup_podcasting\helpers\delete_all_podcast_meta( 42 ));
+		$this->assertNull( tenup_podcasting\helpers\delete_all_podcast_meta( 42 ) );
 
 		$meta_keys = array( 'podcast_url', 'podcast_filesize', 'podcast_duration', 'podcast_mime', 'podcast_captioned', 'podcast_explicit', 'enclosure', 'podcast_season_number', 'podcast_episode_number', 'podcast_episode_type' );
 		foreach ( $meta_keys as $meta_key ) {
 			\WP_Mock::userFunction( 'delete_post_meta' )->with( 42, $meta_key );
 		}
 
-		$this->assertNull(tenup_podcasting\helpers\delete_all_podcast_meta( 42 ));
+		$this->assertNull( tenup_podcasting\helpers\delete_all_podcast_meta( 42 ) );
+	}
+
+	/**
+	 * @dataProvider data_provider_for_test_get_podcast_meta_from_url
+	 * @covers tenup_podcasting\helpers\get_podcast_meta_from_url
+	 */
+	public function test_get_podcast_meta_from_url( $url, $redirect, $headers, $audio_metadata, $expected ) {
+		\WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+
+		if ( $redirect ) {
+			\WP_Mock::userFunction( 'wp_get_http_headers' )->with( $url )->andReturn( array( 'location' => $redirect ) );
+			\WP_Mock::userFunction( 'wp_get_http_headers' )->with( $redirect )->andReturn( $headers );
+		} else {
+			\WP_Mock::userFunction( 'wp_get_http_headers' )->with( $url )->andReturn( $headers );
+		}
+
+		\WP_Mock::userFunction( 'download_url' )->with( $url, 30 )->andReturn( 'downloaded_file_blob' );
+		\WP_Mock::userFunction( 'wp_read_audio_metadata' )->with( 'downloaded_file_blob' )->andReturn( $audio_metadata );
+		\WP_Mock::userFunction( 'wp_parse_url' )->andReturnUsing(
+			function( $url ) {
+				return parse_url( $url );
+			}
+		);
+		\WP_Mock::userFunction( 'wp_get_mime_types' )->andReturn( array( 'mp3|mp4' => 'audio/mpeg' ) );
+
+		$meta = tenup_podcasting\helpers\get_podcast_meta_from_url( $url );
+		$this->assertSame( $expected, $meta );
+	}
+
+	public function data_provider_for_test_get_podcast_meta_from_url() {
+		return array(
+			'Should follow redirect' => array(
+				'url'            => 'https://simple-podcasting.test/correct.mp3',
+				'redirect'       => 'https://simple-podcasting.test/redirected.mp3',
+				'headers'        => array(
+					'content-length' => 42000,
+					'content-type'   => 'audio/mpeg',
+				),
+				'audio_metadata' => array( 'length_formatted' => '0:42' ),
+				'expected' => array(
+					'url' => 'https://simple-podcasting.test/correct.mp3',
+					'mime' => 'audio/mpeg',
+					'duration' => '0:42',
+					'filesize' => 42000
+				),
+			),
+			'Should extract metadata' => array(
+				'url'            => 'https://simple-podcasting.test/correct.mp3',
+				'redirect'       => false,
+				'headers'        => array(
+					'content-length' => 42000,
+					'content-type'   => 'audio/mpeg',
+				),
+				'audio_metadata' => array( 'length_formatted' => '0:42' ),
+				'expected' => array(
+					'url' => 'https://simple-podcasting.test/correct.mp3',
+					'mime' => 'audio/mpeg',
+					'duration' => '0:42',
+					'filesize' => 42000
+				),
+			),
+		);
 	}
 }


### PR DESCRIPTION
### Description of the Change

This PR fixes the mime array key when saving the podcast enclosure with Classic Editor and regular metabox.

Added PHP Unit tests to cover `get_podcast_meta_from_url()`

Closes #157 

### Verification Process

1. Activate Classic Editor
1. Add new podcast episode
1. Specify enclosure file in the meta box
1. Save post
1. Check podcast RSS Feed: the enclosure attribute should be ok

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Fixed - Saving podcast enclosure with Classic Editor

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @cadic @faisal-alvi 
