### PR TITLE
Add summary text to channel description field

### DIFF
--- a/includes/customize-feed.php
+++ b/includes/customize-feed.php
@@ -57,7 +57,7 @@ add_filter( 'wp_audio_shortcode', '__return_empty_string', 999 );
 
 /**
  * Sets the podcast language and description in the feed to the values in the term edit screen.
- * 
+ *
  * @param string $output    The value being displayed.
  * @param string $requested The item that was requested.
  *
@@ -84,7 +84,7 @@ function bloginfo_rss( $output, $requested ) {
 		}
 
 		if ( ! empty( $summary ) ) {
-			$output = "<![CDATA[" . $summary . "]]>";
+			$output = '<![CDATA[' . $summary . ']]>';
 		}
 	}
 	return $output;

--- a/includes/customize-feed.php
+++ b/includes/customize-feed.php
@@ -55,16 +55,15 @@ add_filter( 'wp_title_rss', __NAMESPACE__ . '\bloginfo_rss_name' );
 // Don't show audio widgets in the feed.
 add_filter( 'wp_audio_shortcode', '__return_empty_string', 999 );
 
-
 /**
- * Sets the podcast language in the feed to the one selected in the term edit screen.
- *
+ * Sets the podcast language and description in the feed to the values in the term edit screen.
+ * 
  * @param string $output    The value being displayed.
  * @param string $requested The item that was requested.
  *
  * @return mixed
  */
-function bloginfo_rss_lang( $output, $requested ) {
+function bloginfo_rss( $output, $requested ) {
 	$term = get_the_term();
 	if ( ! $term ) {
 		return $output;
@@ -77,9 +76,20 @@ function bloginfo_rss_lang( $output, $requested ) {
 			$output = $lang;
 		}
 	}
+	if ( 'description' === $requested ) {
+		$summary = get_term_meta( $term->term_id, 'podcasting_summary', true );
+
+		if ( empty( $summary ) ) {
+			$summary = get_bloginfo( 'description' );
+		}
+
+		if ( ! empty( $summary ) ) {
+			$output = "<![CDATA[" . $summary . "]]>";
+		}
+	}
 	return $output;
 }
-add_filter( 'bloginfo_rss', __NAMESPACE__ . '\bloginfo_rss_lang', 10, 2 );
+add_filter( 'bloginfo_rss', __NAMESPACE__ . '\bloginfo_rss', 10, 2 );
 
 /**
  * Add podcasting details to the feed header.


### PR DESCRIPTION
The description field is required and cannot be empty for Spotify podcasts.

Added CDATA according to documentation regarding the description field https://help.apple.com/itc/podcasts_connect/#/itcb54353390

<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

<!-- Enter any applicable Issues here. Example: -->
Closes #203 

### Alternate Designs
It could be that `itunes:summary` on channel level should be replaced by `description`.
On Apple's [documentation page](https://help.apple.com/itc/podcasts_connect/#/itcb54353390) I did't find a trace of `itunes:summary` so it's hard for me to know how removing it or keeping it as duplicate metadata could affect podcast sites.
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks
Only drawback I can think of is if a podcast site makes use of both `description` and `itunes:summary` on channel level, it could look weird as the same info would be used twice.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
I tested to add the feed to Spotify and it now works and the rendering of the channel looks good in the spotify UI.

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->
Added - Description field to rss feed
Fixed - Spotify not accepting feeds with empty `<description>` field
