### PR TITLE
Fix PHP warning after missed constant renaming

### DIFF
--- a/includes/create-podcast.php
+++ b/includes/create-podcast.php
@@ -125,7 +125,7 @@ class Create_Podcast {
 
 		$result = wp_insert_term(
 			$this->podcast_name,
-			TAXONOMY_NAME
+			PODCASTING_TAXONOMY_NAME
 		);
 
 		if ( is_wp_error( $result ) ) {


### PR DESCRIPTION
### Description of the Change
In this PR I'm fixing a PHP fatal error after a missed constant renaming.

<!-- Enter any applicable Issues here. Example: -->
Closes https://github.com/10up/simple-podcasting/issues/246

### Verification Process

1. Activate the plugin for the first time on site or update the simple_podcasting_onboarding option to no, if it is already in use on site.
2. Feel a podcast show details on onboarding and click on create.
3. Verify that when the onboarding finishes there is no PHP warning in the debug log and that there is no notice about the failed creation of the podcast because of an "Invalid taxonomy" error.


<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry
> Fixed - Fixed a PHP warning when creating a new podcast.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @kmgalanakis 
