### PR TITLE
Prevent fatal error in WP 5.8 and earlier.

### DIFF
--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -387,17 +387,16 @@ function latest_episode_query_loop( $query ) {
 /**
  * Latest podcast check.
  *
- * @param String   $pre_render   pre render object.
- * @param Array    $parsed_block parsed block object.
- * @param WP_Block $parent_block parent block object.
+ * @param String $pre_render   pre render object.
+ * @param Array  $parsed_block parsed block object.
  */
-function latest_episode_check( $pre_render, $parsed_block, $parent_block ) {
+function latest_episode_check( $pre_render, $parsed_block ) {
 
 	if ( isset( $parsed_block['attrs']['namespace'] ) && 'podcasting/latest-episode' === $parsed_block['attrs']['namespace'] ) {
 		add_action( 'query_loop_block_query_vars', __NAMESPACE__ . '\latest_episode_query_loop' );
 	}
 }
-add_filter( 'pre_render_block', __NAMESPACE__ . '\latest_episode_check', 10, 3 );
+add_filter( 'pre_render_block', __NAMESPACE__ . '\latest_episode_check', 10, 2 );
 
 /**
  * Latest podcast query in editor.


### PR DESCRIPTION
### Description of the Change

Resolves a fatal error in `latest_episode_check` on older versions of WP before the third parameter was added to the [`pre_render_block` filter](https://developer.wordpress.org/reference/hooks/pre_render_block/).

The parameter was unused so I've simply removed it as PHP will not throw if additional parameters are passed to a function.

There are no back-compat concerns for developers removing the hook as [`remove_filter()`](https://developer.wordpress.org/reference/functions/remove_filter/) does not require the number of arguments be passed.

<!-- Enter any applicable Issues here. Example: -->
Closes #276.

## Testing notes


1. Install WordPress 5.8
2. On board this plugin (set up a taxononmy)
3. Create a post
4. Insert a simple podcasting block and add media
5. Save post

On trunk the post will not save, on this branch it will. 


### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

N/A

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Fixed - Fatal error in WordPress 5.8 and earlier.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @Sidsector9 
