### PR TITLE
Update import statement in CreatePodcastShowModal component

### DIFF
--- a/assets/js/create-podcast-show.js
+++ b/assets/js/create-podcast-show.js
@@ -1,5 +1,5 @@
 import { registerPlugin } from "@wordpress/plugins";
-import { PluginDocumentSettingPanel, store as editPostStore } from '@wordpress/edit-post';
+import { PluginDocumentSettingPanel, store as editPostStore } from '@wordpress/editor';
 import { __ } from "@wordpress/i18n";
 import {
 	Button,

--- a/assets/js/create-podcast-show.js
+++ b/assets/js/create-podcast-show.js
@@ -1,5 +1,5 @@
 import { registerPlugin } from "@wordpress/plugins";
-import { PluginDocumentSettingPanel, store as editPostStore } from '@wordpress/editor';
+import { store as editPostStore } from '@wordpress/edit-post';
 import { __ } from "@wordpress/i18n";
 import {
 	Button,
@@ -15,6 +15,10 @@ import {
 import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
 import { useState, useEffect } from "@wordpress/element";
 import { useSelect, dispatch } from "@wordpress/data";
+
+// Once WordPress 6.6 becomes our minimum, change this back to `import { PluginDocumentSettingPanel } from '@wordpress/editor';`.
+const PluginDocumentSettingPanel = wp.editor?.PluginDocumentSettingPanel ?? ( wp.editPost?.PluginDocumentSettingPanel ?? wp.editSite?.PluginDocumentSettingPanel );
+
 // Due to unsupported versions of React, we're importing stores from the
 // `wp` namespace instead of @wordpress NPM packages for the following.
 const { store: editorStore } = wp.editor;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Update the import statement for PluginDocumentSettingPanel component to use unified extensibility API.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #305

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
No functional changes to the plugin.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Changed import of PluginDocumentSettingPanel component from @wordpress/edit-post to @wordpress/editor

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
