### PR TITLE
Ensure Podcast block updates are backward compatible.

### DIFF
--- a/assets/js/blocks.js
+++ b/assets/js/blocks.js
@@ -7,6 +7,7 @@ import { registerBlockType, registerBlockVariation } from '@wordpress/blocks';
 // Split the Edit component out.
 import Edit from './edit';
 import transforms from './transforms';
+import deprecated from './deprecated';
 import '../css/podcasting-editor-screen.css';
 
 /**
@@ -139,6 +140,7 @@ export default registerBlockType(
 				</figure>
 			);
 		},
+		deprecated,
 	},
 );
 

--- a/assets/js/deprecated.js
+++ b/assets/js/deprecated.js
@@ -1,0 +1,89 @@
+export default [
+	{
+		attributes: {
+			id: {
+				type: 'number',
+			},
+			src: {
+				type: 'string',
+				source: 'attribute',
+				selector: 'audio',
+				attribute: 'src',
+			},
+			url: {
+				type: 'string',
+				source: 'meta',
+				meta: 'podcast_url',
+			},
+			filesize: {
+				type: 'number',
+				source: 'meta',
+				meta: 'podcast_filesize',
+			},
+			duration: {
+				type: 'string',
+				source: 'meta',
+				meta: 'podcast_duration',
+			},
+			mime: {
+				type: 'string',
+				source: 'meta',
+				meta: 'podcast_mime',
+			},
+			caption: {
+				type: 'array',
+				source: 'children',
+				selector: 'figcaption',
+			},
+			captioned: {
+				type: 'boolean',
+				source: 'meta',
+				meta: 'podcast_captioned',
+				default: false,
+			},
+			explicit: {
+				type: 'string',
+				source: 'meta',
+				meta: 'podcast_explicit',
+				default: 'no',
+			},
+			enclosure: {
+				type: 'string',
+				source: 'meta',
+				meta: 'enclosure',
+			},
+			seasonNumber: {
+				type: 'string',
+				source: 'meta',
+				meta: 'podcast_season_number',
+			},
+			episodeNumber: {
+				type: 'string',
+				source: 'meta',
+				meta: 'podcast_episode_number',
+			},
+			episodeType: {
+				type: 'string',
+				source: 'meta',
+				meta: 'podcast_episode_type',
+			}
+		},
+		supports: {
+			multiple: false,
+		},
+		save: props => {
+			const {
+				id,
+				src,
+				caption
+			} = props.attributes;
+
+			return (
+				<figure className={ id ? `podcast-${ id }` : null }>
+					<audio controls="controls" src={ src } />
+					{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
+				</figure>
+			);
+		},
+	},
+];


### PR DESCRIPTION
### Description of the Change
PR fixes the first issue reported in https://github.com/10up/simple-podcasting/issues/313#issuecomment-2304843986

> I tested on an existing post that already had a Podcast block in it and I got the dreaded Block recovery error. Luckily clicking that recovery button did work but it would be ideal if this didn't happen. I know we made some big changes to the block but would be great if those changes could be made backwards compatible.

The issue occurred due to changes in the block markup. PR [#272](https://github.com/10up/simple-podcasting/pull/272) adds a class to the `figcaption` and moves its position above the audio control.

This PR resolves the issue by adding deprecated block markup using the [block deprecation](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-deprecation.md) feature.

_An alternate solution would be to keep the block markup as it is, since we didn't make major changes—just moved the caption above the audio control. Keeping it as is would prevent the invalid content error._ 

### How to test the Change
1. Check out the 1.8.0 release tag.
2. Create a post with a Podcast block and save it.
3. Check out the develop branch, visit the edit post page, and notice the invalid content error on the block.
4. Check out this PR branch, visit the edit post page, and verify that there is no invalid content error on the block. 

### Changelog Entry
> Developer - Ensure Podcast block updates are backward compatible.

### Credits
Props @dkotter @iamdharmesh 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
