### PR TITLE
Bump WordPress "tested up to" version 6.8

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -23,7 +23,7 @@ jobs:
         core:
           - {name: 'WP latest', version: 'latest'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.5'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.6'}
 
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Podcasting is a method to distribute audio messages through a feed to which list
 ## Requirements
 
 * PHP 7.4+
-* [WordPress](http://wordpress.org) 6.5+
+* [WordPress](http://wordpress.org) 6.6+
 * RSS feeds must not be disabled
 
 ## Installation

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Simple Podcasting ===
 Contributors: 10up, helen, adamsilverstein, jakemgold, jeffpaul, cadic
 Tags:         podcasting, podcast, apple podcasts, episode, season
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag:   1.9.0
 License:      GPLv2 or later
 License URI:  http://www.gnu.org/licenses/gpl-2.0.html
@@ -100,7 +100,7 @@ add_filter( 'simple_podcasting_feed_item', 'podcasting_feed_item_filter', 10, 3 
 
 === Technical Notes ===
 
-* Requires PHP 5.3+.
+* Requires PHP 7.4+.
 * RSS feeds must not be disabled.
 
 == Screenshots ==

--- a/simple-podcasting.php
+++ b/simple-podcasting.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/10up/simple-podcasting
  * Description:       Easily set up multiple podcast feeds using built-in WordPress posts. Includes a podcast block for the new WordPress editor.
  * Version:           1.9.0
- * Requires at least: 6.5
+ * Requires at least: 6.6
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        http://10up.com/


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR bumps the WP tested-up-to 6.8 and WP min to 6.6.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #334.

### How to test the Change
Already tested via https://github.com/10up/simple-podcasting/issues/334#issuecomment-2828705470, but will want to see that e2e tests pass here as well.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Bump WordPress "tested up to" version 6.8.
> Changed - Bump WordPress minimum to version 6.6.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
