### PR TITLE
Remove `makepot` from `prebuild`, add `makepot` to deploy

### DIFF
--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         npm ci
         npm run build
+        npm run makepot
 
     - name: WordPress Plugin Deploy
       id: deploy

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "build": "wp-scripts build",
     "deploy": "npm install && npm run build",
     "makepot": "wpi18n makepot --domain-path languages --pot-file simple-podcasting.pot --type plugin --main-file simple-podcasting.php --exclude node_modules,tests,docs,vendor",
-    "prebuild": "npm run makepot",
     "prepare": "husky install",
     "wp-env": "wp-env",
     "env:start": "wp-env start",


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR removes `makepot` from every `prebuild` and only generates a POT file during the final deploy to dotorg. See move in the comments starting with https://github.com/10up/simple-podcasting/pull/336#issuecomment-2828769802.

### How to test the Change
Run a build and see no updated POT file, run a deploy and see an updated POT file (and hopefully a future WP tested-up-to bump that properly gets to dotorg via the Readme Updater action).

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Developer - Adjust `makepot` to only happen during deploy instead of during every prebuild.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul, @dkotter 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
