### PR TITLE
Fix/workflow perms

### DIFF
--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -1,5 +1,8 @@
 name: Build release zip
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,9 @@
 name: E2E Test
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches:

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -1,5 +1,8 @@
 name: PHP Compatibility
 
+permissions:
+  contents: read
+
 env:
   COMPOSER_VERSION: "2"
   COMPOSER_CACHE: "${{ github.workspace }}/.composer-cache"

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,5 +1,8 @@
 name: PHPCS
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,5 +1,8 @@
 name: Unit Tests
 
+permissions:
+  contents: read
+
 env:
   COMPOSER_VERSION: "2"
   COMPOSER_CACHE: "${{ github.workspace }}/.composer-cache"

--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -5,6 +5,9 @@ on:
     branches:
     - trunk
 
+permissions:
+  contents: read
+
 jobs:
   trunk:
     name: Push to trunk

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -1,5 +1,10 @@
 name: Deploy to WordPress.org
 
+permissions:
+  contents: read
+  packages: read
+  actions: write
+
 on:
   release:
     types: [published]

--- a/.github/workflows/repo-automator.yml
+++ b/.github/workflows/repo-automator.yml
@@ -1,5 +1,9 @@
 name: 'Repo Automator'
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   issues:
     types:


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This pull request updates GitHub Actions workflows to explicitly define permissions for improved security and clarity. Permissions are added to ensure that each workflow has only the access it needs to perform its tasks.

### Workflow permission updates:

* [`.github/workflows/build-release-zip.yml`](diffhunk://#diff-948bce84fd4ffebcbf8f82de6162123178817db71cecfb56a7fa79a9535676ecR3-R5): Added `contents: read` permission to allow the workflow to read repository contents.
* [`.github/workflows/cypress.yml`](diffhunk://#diff-5da9a41590fb261de0e464c95862528100c42c77dffad53b7c6de228b6afd2bdR3-R6): Added `contents: read` and `pull-requests: write` permissions to enable end-to-end testing workflows to read repository contents and interact with pull requests.
* [`.github/workflows/php-compatibility.yml`](diffhunk://#diff-93c2990b81df932a8ebe1a2f9ac5167d82d3193205e8878d0987d10048061e3fR3-R5): Added `contents: read` permission for compatibility checks.
* [`.github/workflows/phpcs.yml`](diffhunk://#diff-f621c7ec73ae73c758a64d5f030f2062fc73f50676d953035650636c052aac3fR3-R5): Added `contents: read` permission for PHPCS linting workflows.
* [`.github/workflows/phpunit.yml`](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510R3-R5): Added `contents: read` permission for unit testing workflows.
* [`.github/workflows/push-asset-readme-update.yml`](diffhunk://#diff-da3ba00836cc30a1497ac5cd5b51eba2baa577ae0a53e64a2263cc6f849e444bR8-R10): Added `contents: read` permission for workflows that push README updates to the trunk branch.
* [`.github/workflows/push-deploy.yml`](diffhunk://#diff-d71c3ba30cee07edf9485b33d2e7ee90f8abcb8c853798bea3437187ebb055bbR3-R7): Added `contents: read`, `packages: read`, and `actions: write` permissions to support deployment workflows to WordPress.org.
* [`.github/workflows/repo-automator.yml`](diffhunk://#diff-1c38000792e37fe51624d4be0089820da8c58940b859fbbc85561037d1a07118R3-R6): Added `contents: read` and `issues: write` permissions for repository automation workflows.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

n/a

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
