### PR TITLE
Bump tested up to header to indicate WordPress 6.9 support.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Simple Podcasting ===
 Contributors: 10up, helen, adamsilverstein, jakemgold, jeffpaul, cadic
 Tags:         podcasting, podcast, apple podcasts, episode, season
-Tested up to: 6.8
+Tested up to: 6.9
 Stable tag:   1.9.1
 License:      GPLv2 or later
 License URI:  http://www.gnu.org/licenses/gpl-2.0.html

--- a/tests/cypress/integration/block.test.js
+++ b/tests/cypress/integration/block.test.js
@@ -74,7 +74,9 @@ describe('Admin can publish posts with podcast block', () => {
 			cy.get('.components-snackbar', { timeout: 10000 }).should(
 				'be.visible'
 			);
-			cy.get('a.components-button.components-snackbar__action').click();
+			cy.get(
+				'a.components-snackbar__action:is(.components-button, .components-external-link)'
+			).click();
 			cy.get('.wp-block-podcasting-podcast audio')
 				.should('have.attr', 'src')
 				.and('include', 'example');


### PR DESCRIPTION
### Description of the Change

Bump tested up to header to indicate WordPress 6.9 support.

Closes #348 

### How to test the Change

N/A: See testing notes on the related issue.

### Changelog Entry
> Changed - Bump tested up to header to indicate WordPress 6.9 support.

### Credits
Props @peterwilsoncc 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
