### PR TITLE
add patchstack to faq in readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,18 +71,6 @@ Podcast Platforms block | Podcast Grid pattern | Podcast Transcript block
 * Validate your feeds at [Cast Feed Validator](https://www.castfeedvalidator.com/) before submitting them.
 * Submit the podcast feed to https://pocketcasts.com/submit/
 
-### How do I get my podcast featured on Pocket Casts?
-
-The Featured section of Pocket Casts is human-curated. To ensure that all podcasts have an equal opportunity at being featured, selections are made on the basis of merit.
-
-If you’d like to suggest your podcast for a featured spot, reach out to curation@pocketcasts.com.
-
-For more information, [read more](https://pocketcasts.com/podcast-producers/).
-
-### How do I submit private and paid podcast feeds?
-
-Follow this documentation to submit [private and paid podcast feeds](https://support.pocketcasts.com/article/password-protected-podcasts-2/)
-
 ## Control how many episodes are listed on the feed
 
 If you want to adjust the default number of episodes included in a podcast RSS feed, then utilize the following to do so...
@@ -142,6 +130,24 @@ function podcasting_feed_item_filter( $feed_item = array(), $post_id = null, $te
 }
 add_filter( 'simple_podcasting_feed_item', 'podcasting_feed_item_filter', 10, 3 );
 ```
+
+## Frequently Asked Questions
+
+### How do I get my podcast featured on Pocket Casts?
+
+The Featured section of Pocket Casts is human-curated. To ensure that all podcasts have an equal opportunity at being featured, selections are made on the basis of merit.
+
+If you’d like to suggest your podcast for a featured spot, reach out to curation@pocketcasts.com.
+
+For more information, [read more](https://pocketcasts.com/podcast-producers/).
+
+### How do I submit private and paid podcast feeds?
+
+Follow this documentation to submit [private and paid podcast feeds](https://support.pocketcasts.com/article/password-protected-podcasts-2/)
+
+### Where do I report security bugs found in this plugin?
+
+Please report security bugs found in the source code of the Simple Podcasting plugin through the [Patchstack Vulnerability Disclosure  Program](https://patchstack.com/database/vdp/0d49ba54-688e-484d-9411-4716696aa79b).  The Patchstack team will assist you with verification, CVE assignment, and notify the developers of this plugin.
 
 ## Support Level
 

--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,21 @@ Set up multiple podcast feeds using built-in WordPress posts. Includes a podcast
 
 Podcasting is a method to distribute audio and video episodes through a feed to which listeners can subscribe. You can publish podcasts on your WordPress site and make them available for listeners in Apple Podcasts and through direct feed links for other podcasting apps by following these steps:
 
-=== Create your podcast ===
+= Technical Notes =
+
+* Requires PHP 7.4+.
+* RSS feeds must not be disabled.
+
+== Installation ==
+
+1. Install the plugin via the plugin installer, either by searching for it or uploading a .zip file.
+2. Activate the plugin.
+3. Head to Posts → Podcasts and add at least one podcast.
+4. Create a post and insert an audio embed (or a podcast block in Gutenberg) and select a Podcast feed to include it in.
+
+== Usage ==
+
+= Create your podcast =
 
 From the WordPress Admin, go to Podcasts.
 To create a podcast, complete all of the "Add New Podcast" fields and click "Add New Podcast".
@@ -34,37 +48,25 @@ To create a podcast, complete all of the "Add New Podcast" fields and click "Add
 
 Repeat for each podcast you would like to create.
 
-=== Add content to your podcast ===
+= Add content to your podcast =
 
  * Create a new post and assign it to one or more Podcasts using the panel labeled Podcasts.
  * Upload or embed an audio file into this post using any of the usual WordPress methods. If using the new block-based WordPress editor (sometimes referred to as Gutenberg), insert a Podcast block. Only one Podcast block can be inserted per post.
  * For more advanced settings, use the Podcasting meta box to mark explicit content or closed captioning available, season number, episode number, episode type, add a transcript and to optionally specify one media item in the post if you have more than one in your post. In the block-based editor, these are the block settings that appear in the sidebar when the podcast block is selected.
  * Transcript: If desired, an optional transcript can be added from the settings of the Podcast block. This will add a Podcast Transcript block, allowing you to add a transcript consisting of time codes, citations, and paragrah text that can be embedded in the post, linked to an external plain HTML file, or linked in a special `<podcast:transcript>` XML element.
 
-=== Submit your podcast feed to Apple Podcasts ===
+= Submit your podcast feed to Apple Podcasts =
 
 * Each podcast has a unique feed URL you can find on the Podcasts page. This is the URL you will submit to Apple.
 * Ensure you test feeds before submitting them, see [Apple's "Test a Podcast page"](https://help.apple.com/itc/podcasts_connect/#/itcac471c970) for more information.
 * Once the validator passes, submit your podcast. Podcasts submitted to Apple Podcasts do not become immediately available for subscription by others. They are submitted for review by Apple staff, see [Apple's "Submit a podcast" page](https://help.apple.com/itc/podcasts_connect/#/itcd88ea40b9) for more information.
 
-=== Submit your podcast feed to Pocket Casts
+= Submit your podcast feed to Pocket Casts =
 
 * Validate your feeds at [https://www.castfeedvalidator.com/ Cast Feed Validator] before submitting them.
 * Submit the podcast feed to https://pocketcasts.com/submit/.
 
-=== How do I get my podcast featured on Pocket Casts?
-
-The Featured section of Pocket Casts is human-curated. To ensure that all podcasts have an equal opportunity at being featured, selections are made on the basis of merit.
-
-If you’d like to suggest your podcast for a featured spot, reach out to `curation@pocketcasts.com`
-
-For more information, [https://pocketcasts.com/podcast-producers/ read more].
-
-=== How do I submit private and paid podcast feeds?
-
-Follow this documentation to submit [https://support.pocketcasts.com/article/password-protected-podcasts-2/ private and paid podcast feeds]
-
-=== Control how many episodes are listed on the feed ===
+= Control how many episodes are listed on the feed =
 
 If you want to adjust the default number of episodes included in a podcast RSS feed, then utilize the following to do so...
 
@@ -84,7 +86,7 @@ function podcasting_feed_episodes_per_page( $qty ) {
 }
 `
 
-=== Customize RSS feed ===
+= Customize RSS feed =
 
 If you want to modify RSS feed items output, there is a filter for that:
 
@@ -98,10 +100,23 @@ function podcasting_feed_item_filter( $feed_item = array(), $post_id = null, $te
 add_filter( 'simple_podcasting_feed_item', 'podcasting_feed_item_filter', 10, 3 );
 `
 
-=== Technical Notes ===
+== Frequently Asked Questions ==
 
-* Requires PHP 7.4+.
-* RSS feeds must not be disabled.
+= How do I get my podcast featured on Pocket Casts? =
+
+The Featured section of Pocket Casts is human-curated. To ensure that all podcasts have an equal opportunity at being featured, selections are made on the basis of merit.
+
+If you’d like to suggest your podcast for a featured spot, reach out to `curation@pocketcasts.com`
+
+For more information, [https://pocketcasts.com/podcast-producers/ read more].
+
+= How do I submit private and paid podcast feeds? =
+
+Follow this documentation to submit [https://support.pocketcasts.com/article/password-protected-podcasts-2/ private and paid podcast feeds]
+
+= Where do I report security bugs found in this plugin? =
+
+Please report security bugs found in the source code of the Simple Podcasting plugin through the [Patchstack Vulnerability Disclosure  Program](https://patchstack.com/database/vdp/0d49ba54-688e-484d-9411-4716696aa79b).  The Patchstack team will assist you with verification, CVE assignment, and notify the developers of this plugin.
 
 == Screenshots ==
 
@@ -111,13 +126,6 @@ add_filter( 'simple_podcasting_feed_item', 'podcasting_feed_item_filter', 10, 3 
 4. Podcast feed
 5. Podcast Grid pattern
 6. Podcast Transcript block
-
-== Installation ==
-
-1. Install the plugin via the plugin installer, either by searching for it or uploading a .zip file.
-2. Activate the plugin.
-3. Head to Posts → Podcasts and add at least one podcast.
-4. Create a post and insert an audio embed (or a podcast block in Gutenberg) and select a Podcast feed to include it in.
 
 == Changelog ==
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This pull request updates the documentation for the Simple Podcasting plugin, focusing on improving organization, clarity, and accessibility of key information for users. The most notable changes include restructuring the `readme.txt` and `README.md` files, moving frequently asked questions (FAQ) into a dedicated section, and adding instructions for reporting security bugs.

**Documentation restructuring and clarity:**

* Reorganized `readme.txt` to use more consistent section headings (e.g., `= Create your podcast =`) and improved the step-by-step instructions for installation and usage. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L17-R31) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L37-R69)
* Moved FAQ content (“How do I get my podcast featured on Pocket Casts?”, “How do I submit private and paid podcast feeds?”) into a dedicated “Frequently Asked Questions” section in both `readme.txt` and `README.md` for better visibility and easier access. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-L85) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R134-R151) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L101-R119)

**Security and support information:**

* Added instructions on how to report security bugs via the Patchstack Vulnerability Disclosure Program to both documentation files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R134-R151) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L101-R119)
* Clarified support level and technical requirements, such as PHP version and RSS feed prerequisites, in the documentation. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L17-R31) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L101-R119)

**Minor formatting and consistency fixes:**

* Standardized section headings throughout `readme.txt` for easier navigation and improved readability. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L37-R69) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L87-R89)
* Removed duplicate and outdated FAQ content from the main body and consolidated it under the new FAQ section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-L85) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L37-R69)

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Developer - Add Patchstack security-reporting FAQ.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
