### PR TITLE
Fix ESLint plugin dependencies

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,5 @@
+node_modules/
+dist/
+build/
+vendor/
 assets/js/frontend/vendor/*.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,0 @@
-{
-	"extends": [ "plugin:@wordpress/eslint-plugin/recommended" ],
-	"ignorePatterns": ["**/vendor/**"]
-}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+	"globals": {
+		"jQuery": "readonly",
+		"wp": "readonly",
+		"FormData": "readonly",
+		"fetch": "readonly",
+		"ajaxurl": "readonly"
+	},
+	"settings": {
+		"import/core-modules": [
+			"@wordpress/api-fetch",
+			"@wordpress/block-editor",
+			"@wordpress/blocks",
+			"@wordpress/components",
+			"@wordpress/compose",
+			"@wordpress/core-data",
+			"@wordpress/data",
+			"@wordpress/date",
+			"@wordpress/edit-post",
+			"@wordpress/element",
+			"@wordpress/i18n",
+			"@wordpress/plugins",
+			"@wordpress/primitives",
+			"@wordpress/rich-text"
+		]
+	},
+	"extends": "plugin:@wordpress/eslint-plugin/recommended"
+}

--- a/assets/js/blocks.js
+++ b/assets/js/blocks.js
@@ -13,141 +13,141 @@ import '../css/podcasting-editor-screen.css';
 /**
  * Register example block
  */
-export default registerBlockType(
-	'podcasting/podcast',
-	{
-		title: __( 'Podcast', 'simple-podcasting' ),
-		description: __( 'Insert a podcast episode into a post. To add it to a podcast feed, select a podcast in document settings.', 'simple-podcasting' ),
-		category: 'common',
-		icon: 'microphone',
-		supports: {
-			multiple: false,
-		},
-		attributes: {
-			id: {
-				type: 'number',
-			},
-			src: {
-				type: 'string',
-				source: 'attribute',
-				selector: 'audio',
-				attribute: 'src',
-			},
-			url: {
-				type: 'string',
-				source: 'meta',
-				meta: 'podcast_url',
-			},
-			filesize: {
-				type: 'number',
-				source: 'meta',
-				meta: 'podcast_filesize',
-			},
-			duration: {
-				type: 'string',
-				source: 'meta',
-				meta: 'podcast_duration',
-			},
-			mime: {
-				type: 'string',
-				source: 'meta',
-				meta: 'podcast_mime',
-			},
-			caption: {
-				type: 'array',
-				source: 'children',
-				selector: 'figcaption',
-			},
-			captioned: {
-				type: 'boolean',
-				source: 'meta',
-				meta: 'podcast_captioned',
-				default: false,
-			},
-			explicit: {
-				type: 'string',
-				source: 'meta',
-				meta: 'podcast_explicit',
-			},
-			enclosure: {
-				type: 'string',
-				source: 'meta',
-				meta: 'enclosure',
-			},
-			seasonNumber: {
-				type: 'string',
-				source: 'meta',
-				meta: 'podcast_season_number',
-			},
-			episodeNumber: {
-				type: 'string',
-				source: 'meta',
-				meta: 'podcast_episode_number',
-			},
-			episodeType: {
-				type: 'string',
-				source: 'meta',
-				meta: 'podcast_episode_type',
-			},
-			displayDuration: {
-				type: 'boolean',
-				default: false,
-			},
-			displayShowTitle: {
-				type: 'boolean',
-				default: false,
-			},
-			displayEpisodeTitle: {
-				type: 'boolean',
-				default: false,
-			},
-			displayArt: {
-				type: 'boolean',
-				default: false,
-			},
-			displayExplicitBadge: {
-				type: 'boolean',
-				default: false,
-			},
-			displaySeasonNumber: {
-				type: 'boolean',
-				default: false,
-			},
-			displayEpisodeNumber: {
-				type: 'boolean',
-				default: false,
-			},
-			displayEpisodeType: {
-				type: 'boolean',
-				default: false,
-			},
-			isDocked: {
-				type: 'string',
-				default: 'none',
-				enum: ['none', 'top', 'bottom'],
-			},
-		},
-		transforms,
-
-		edit: Edit,
-
-		save: props => {
-			const {
-				id,
-				src,
-				caption
-			} = props.attributes;
-
-			return (
-				<figure className={ id ? `podcast-${ id }` : null }>
-					{ caption && caption.length > 0 && <figcaption className="wp-block-podcasting-podcast__caption">{ caption }</figcaption> }
-					<audio controls="controls" src={ src } />
-				</figure>
-			);
-		},
-		deprecated,
+export default registerBlockType('podcasting/podcast', {
+	title: __('Podcast', 'simple-podcasting'),
+	description: __(
+		'Insert a podcast episode into a post. To add it to a podcast feed, select a podcast in document settings.',
+		'simple-podcasting'
+	),
+	category: 'common',
+	icon: 'microphone',
+	supports: {
+		multiple: false,
 	},
-);
+	attributes: {
+		id: {
+			type: 'number',
+		},
+		src: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'audio',
+			attribute: 'src',
+		},
+		url: {
+			type: 'string',
+			source: 'meta',
+			meta: 'podcast_url',
+		},
+		filesize: {
+			type: 'number',
+			source: 'meta',
+			meta: 'podcast_filesize',
+		},
+		duration: {
+			type: 'string',
+			source: 'meta',
+			meta: 'podcast_duration',
+		},
+		mime: {
+			type: 'string',
+			source: 'meta',
+			meta: 'podcast_mime',
+		},
+		caption: {
+			type: 'array',
+			source: 'children',
+			selector: 'figcaption',
+		},
+		captioned: {
+			type: 'boolean',
+			source: 'meta',
+			meta: 'podcast_captioned',
+			default: false,
+		},
+		explicit: {
+			type: 'string',
+			source: 'meta',
+			meta: 'podcast_explicit',
+		},
+		enclosure: {
+			type: 'string',
+			source: 'meta',
+			meta: 'enclosure',
+		},
+		seasonNumber: {
+			type: 'string',
+			source: 'meta',
+			meta: 'podcast_season_number',
+		},
+		episodeNumber: {
+			type: 'string',
+			source: 'meta',
+			meta: 'podcast_episode_number',
+		},
+		episodeType: {
+			type: 'string',
+			source: 'meta',
+			meta: 'podcast_episode_type',
+		},
+		displayDuration: {
+			type: 'boolean',
+			default: false,
+		},
+		displayShowTitle: {
+			type: 'boolean',
+			default: false,
+		},
+		displayEpisodeTitle: {
+			type: 'boolean',
+			default: false,
+		},
+		displayArt: {
+			type: 'boolean',
+			default: false,
+		},
+		displayExplicitBadge: {
+			type: 'boolean',
+			default: false,
+		},
+		displaySeasonNumber: {
+			type: 'boolean',
+			default: false,
+		},
+		displayEpisodeNumber: {
+			type: 'boolean',
+			default: false,
+		},
+		displayEpisodeType: {
+			type: 'boolean',
+			default: false,
+		},
+		isDocked: {
+			type: 'string',
+			default: 'none',
+			enum: ['none', 'top', 'bottom'],
+		},
+	},
+	transforms,
+
+	edit: Edit,
+
+	save: (props) => {
+		const { id, src, caption } = props.attributes;
+
+		return (
+			<figure className={id ? `podcast-${id}` : null}>
+				{caption && caption.length > 0 && (
+					<figcaption className="wp-block-podcasting-podcast__caption">
+						{caption}
+					</figcaption>
+				)}
+				<audio controls="controls" src={src} />
+			</figure>
+		);
+	},
+	deprecated,
+});
 
 const VARIATION_NAME = 'podcasting/latest-episode';
 
@@ -164,23 +164,31 @@ registerBlockVariation('core/query', {
 			podcastingQuery: 'not_empty',
 		},
 	},
-	allowedControls: [ ],
-	scope: [ 'inserter' ],
+	allowedControls: [],
+	scope: ['inserter'],
 	innerBlocks: [
 		[
 			'core/post-template',
 			{},
-			[ [
-				'core/group',
-				{ className: 'podcasting-latest-episode' },
+			[
 				[
-					[ 'core/post-featured-image' ],
-					[ 'core/group', { className: 'podcasting-latest-episode__content' }, [
-						[ 'core/post-title' ], [ 'core/post-date' ], [ 'core/post-excerpt' ]
-					] ],
-				]
-			] ],
+					'core/group',
+					{ className: 'podcasting-latest-episode' },
+					[
+						['core/post-featured-image'],
+						[
+							'core/group',
+							{ className: 'podcasting-latest-episode__content' },
+							[
+								['core/post-title'],
+								['core/post-date'],
+								['core/post-excerpt'],
+							],
+						],
+					],
+				],
+			],
 		],
-		[ 'core/query-no-results' ],
+		['core/query-no-results'],
 	],
 });

--- a/assets/js/blocks/podcast-platforms/edit.js
+++ b/assets/js/blocks/podcast-platforms/edit.js
@@ -14,49 +14,44 @@ import {
 	BaseControl,
 	Button,
 	ButtonGroup,
-	Icon
+	Icon,
 } from '@wordpress/components';
 
-
-function Edit( props ) {
+function Edit(props) {
 	const {
 		setAttributes,
 		isSelected,
-		attributes: {
-			showId,
-			iconSize,
-			align,
-		},
+		attributes: { showId, iconSize, align },
 	} = props;
 
 	/** State for the search text for the show name. Defaults to empty string. */
-	const [ searchText, setSearchText ] = useState( '' );
+	const [searchText, setSearchText] = useState('');
 
 	/** Debounced search text so that we don't trigger useEffect() for every character change. */
-	const [ debouncedSearchText ] = useDebounce( searchText, 300 );
+	const [debouncedSearchText] = useDebounce(searchText, 300);
 
 	/** Indicates when the ajax search for podcasts is completed. */
-	const [ isSearchCompleted, setIsSearchCompleted ] = useState( false );
+	const [isSearchCompleted, setIsSearchCompleted] = useState(false);
 
 	/** State for search results matched by the search text. Defaults to array. */
-	const [ searchResults, setSearchResults ] = useState( [] );
+	const [searchResults, setSearchResults] = useState([]);
 
 	/** State for the icon theme. Defaults to `color`. */
-	const [ iconTheme, setIconTheme ] = useState( 'color' );
+	const [iconTheme, setIconTheme] = useState('color');
 
 	/** State for platforms returned for a specific show. Defaults to array. */
-	const [ platforms, setPlatforms ] = useState( [] );
+	const [platforms, setPlatforms] = useState([]);
 
 	/**
 	 * Hits the `/wp/v2/search` endpoint to search for
 	 * podcast show by name.
 	 */
-	useEffect( () => {
+	useEffect(() => {
 		const searchPodcastShow = async () => {
-			setIsSearchCompleted( false );
+			setIsSearchCompleted(false);
 
-			if ( ! searchText.length ) {
-				setSearchResults( [] );
+			if (!searchText.length) {
+				setSearchResults([]);
 				return;
 			}
 
@@ -64,72 +59,72 @@ function Edit( props ) {
 			const queryObject = {
 				search: searchText,
 				type: 'term',
-				subtype: 'podcasting_podcasts'
+				subtype: 'podcasting_podcasts',
 			};
 
 			/** Converts an object to query-string. */
-			const queryString = new URLSearchParams( queryObject ).toString();
+			const queryString = new URLSearchParams(queryObject).toString();
 
 			/** Returns the results of the search. */
-			const searchResults = await apiFetch( {
-				path: `/wp/v2/search?${ queryString }`,
-			} );
+			const searchResults = await apiFetch({
+				path: `/wp/v2/search?${queryString}`,
+			});
 
-			if ( ! searchResults.length ) {
-				setIsSearchCompleted( true );
+			if (!searchResults.length) {
+				setIsSearchCompleted(true);
 			}
 
-			setSearchResults( searchResults );
-			setIsSearchCompleted( true );
+			setSearchResults(searchResults);
+			setIsSearchCompleted(true);
 		};
 
 		searchPodcastShow();
-	}, [ debouncedSearchText ] );
+	}, [debouncedSearchText]);
 
 	/**
 	 * Fetches the podcasting platforms for a show whenever
 	 * showId updates.
 	 */
-	useEffect( () => {
-		if ( ! showId ) {
+	useEffect(() => {
+		if (!showId) {
 			return;
 		}
 
 		/**
 		 * Responsible to fetch platforms for a show by show ID.
-		 * @returns void
+		 * @return void
 		 */
 		const fetchPlatforms = async () => {
-			const result = await apiFetch( {
-				url: `${ ajaxurl }?show_id=${ showId }&action=get_podcast_platforms`,
-			} );
+			const result = await apiFetch({
+				url: `${ajaxurl}?show_id=${showId}&action=get_podcast_platforms`,
+			});
 
-			if ( ! result.success ) {
-				setPlatforms( [] );
+			if (!result.success) {
+				setPlatforms([]);
 				return;
 			}
 
 			const {
-				data: { platforms, theme }
+				data: { platforms, theme },
 			} = result;
 
-			setPlatforms( platforms );
-			setIconTheme( theme );
+			setPlatforms(platforms);
+			setIconTheme(theme);
 		};
 
 		fetchPlatforms();
-	}, [ showId ] );
+	}, [showId]);
 
 	/**
 	 * Handler to set the attribute showId.
 	 *
 	 * @param {Int} termId The show ID.
-	 * @returns void
+	 * @return void
 	 */
-	const onShowSelect = ( termId ) => {
-		setAttributes( { showId: termId } );
-		setSearchResults( [] );
-		setIsSearchCompleted( false );
+	const onShowSelect = (termId) => {
+		setAttributes({ showId: termId });
+		setSearchResults([]);
+		setIsSearchCompleted(false);
 	};
 
 	/**
@@ -137,130 +132,154 @@ function Edit( props ) {
 	 *
 	 * @param {Int} size The icon size in `px`
 	 */
-	const setIconSize = ( size ) => {
-		setAttributes( { iconSize: size } );
+	const setIconSize = (size) => {
+		setAttributes({ iconSize: size });
 	};
 
 	/**
 	 * Sets the HTML attributes for the root element.
 	 */
-	const blockProps = useBlockProps( {
-		className: isSelected ? 'simple-podcasting__podcast-platforms simple-podcasting__podcast-platforms--selected' : 'simple-podcasting__podcast-platforms',
-	} );
+	const blockProps = useBlockProps({
+		className: isSelected
+			? 'simple-podcasting__podcast-platforms simple-podcasting__podcast-platforms--selected'
+			: 'simple-podcasting__podcast-platforms',
+	});
 
-	const platformSlugs = Object.keys( platforms );
+	const platformSlugs = Object.keys(platforms);
 
 	return (
 		<>
 			<InspectorControls>
-				<Panel header={ __( 'Customization Controls', 'simple-podacsting' ) }>
+				<Panel
+					header={__('Customization Controls', 'simple-podacsting')}
+				>
 					<PanelBody>
-						<BaseControl label={ __( 'Icon size', 'simple-podcasting' ) }/>
+						<BaseControl
+							label={__('Icon size', 'simple-podcasting')}
+						/>
 						<PanelRow>
 							<RangeControl
-								min={ 16 }
-								max={ 96 }
-								step={ 16 }
-								value={ iconSize }
-								onChange={ setIconSize }
+								min={16}
+								max={96}
+								step={16}
+								value={iconSize}
+								onChange={setIconSize}
 							/>
 						</PanelRow>
-						<BaseControl label={ __( 'Alignment', 'simple-podcasting' ) }/>
+						<BaseControl
+							label={__('Alignment', 'simple-podcasting')}
+						/>
 						<PanelRow>
 							<ButtonGroup>
 								<Button
-									isPressed={ align === 'left' }
-									variant='ternary'
-									icon={ <Icon icon='align-left' /> }
-									onClick={ () => setAttributes( { align: 'left' } ) }
+									isPressed={align === 'left'}
+									variant="ternary"
+									icon={<Icon icon="align-left" />}
+									onClick={() =>
+										setAttributes({ align: 'left' })
+									}
 								/>
 								<Button
-									isPressed={ align === 'center' }
-									variant='ternary'
-									icon={ <Icon icon='align-center' /> }
-									onClick={ () => setAttributes( { align: 'center' } ) }
+									isPressed={align === 'center'}
+									variant="ternary"
+									icon={<Icon icon="align-center" />}
+									onClick={() =>
+										setAttributes({ align: 'center' })
+									}
 								/>
 								<Button
-									isPressed={ align === 'right' }
-									variant='ternary'
-									icon={ <Icon icon='align-right' /> }
-									onClick={ () => setAttributes( { align: 'right' } ) }
+									isPressed={align === 'right'}
+									variant="ternary"
+									icon={<Icon icon="align-right" />}
+									onClick={() =>
+										setAttributes({ align: 'right' })
+									}
 								/>
 							</ButtonGroup>
 						</PanelRow>
 					</PanelBody>
 				</Panel>
 			</InspectorControls>
-			<div { ...blockProps }>
-				{
-					platformSlugs.length ? (
-						<div className={ `simple-podcasting__podcasting-platform-list simple-podcasting__podcasting-platform-list--${ align }` }>
-							{
-								platformSlugs.map( ( platform, index ) => {
-									return (
-										<span key={ index } className='simple-podcasting__podcasting-platform-list-item'>
-											<a href={ platforms[ platform ] } target="_blank">
-												<img className={ `simple-pocasting__icon-size--${ iconSize }` } src={ `${ podcastingPlatformVars.podcastingUrl }dist/images/icons/${ platform }/${ iconTheme }-100.png` } />
-											</a>
-										</span>
-									);
-								} )
-							}
-						</div>
-					) : (
-						<div className={ `simple-podcasting__podcasting-platform-list` }>
-							<p>{ __( 'No platforms are set for this podcast.', 'simple-podcasting' ) }</p>
-						</div>
-					)
-				}
-				{
-					isSelected || ! showId ? (
-						<div className='simple-podcasting__podcasting-search-controls'>
-							<SearchControl
-								placeholder={ __( 'Search a Podcast Show', 'simple-podcasting' ) }
-								onChange={ ( searchText ) => setSearchText( searchText ) }
-								value={ searchText }
-							/>
-							{
-								searchResults.length ?
-								(
-									<div className='simple-podcasting__podcasting-search-results'>
-										<ItemGroup
-											isSeparated
-										>
-											{
-												searchResults.map( ( result ) => (
-													<Item
-														key={ result.id }
-														className='simple-podcasting__podcast-search-results'
-														onClick={ () => onShowSelect( result.id ) }
-													>
-														{ result.title }
-													</Item>
-												) )
+			<div {...blockProps}>
+				{platformSlugs.length ? (
+					<div
+						className={`simple-podcasting__podcasting-platform-list simple-podcasting__podcasting-platform-list--${align}`}
+					>
+						{platformSlugs.map((platform, index) => {
+							return (
+								<span
+									key={index}
+									className="simple-podcasting__podcasting-platform-list-item"
+								>
+									<a
+										href={platforms[platform]}
+										target="_blank"
+										rel="noreferrer"
+									>
+										<img
+											className={`simple-pocasting__icon-size--${iconSize}`}
+											src={`${podcastingPlatformVars.podcastingUrl}dist/images/icons/${platform}/${iconTheme}-100.png`}
+										/>
+									</a>
+								</span>
+							);
+						})}
+					</div>
+				) : (
+					<div
+						className={`simple-podcasting__podcasting-platform-list`}
+					>
+						<p>
+							{__(
+								'No platforms are set for this podcast.',
+								'simple-podcasting'
+							)}
+						</p>
+					</div>
+				)}
+				{isSelected || !showId ? (
+					<div className="simple-podcasting__podcasting-search-controls">
+						<SearchControl
+							placeholder={__(
+								'Search a Podcast Show',
+								'simple-podcasting'
+							)}
+							onChange={(searchText) => setSearchText(searchText)}
+							value={searchText}
+						/>
+						{searchResults.length ? (
+							<div className="simple-podcasting__podcasting-search-results">
+								<ItemGroup isSeparated>
+									{searchResults.map((result) => (
+										<Item
+											key={result.id}
+											className="simple-podcasting__podcast-search-results"
+											onClick={() =>
+												onShowSelect(result.id)
 											}
-										</ItemGroup>
-									</div>
-								) : (
-									! searchResults.length && isSearchCompleted ? (
-										<div className='simple-podcasting__podcasting-search-results'>
-											<ItemGroup
-												isSeparated
-											>
-												<Item>
-													{ __( 'No results found.' , 'simple-podcasting') }
-												</Item>
-											</ItemGroup>
-										</div>
-									) : null
-								)
-							}
-						</div>
-					) : null
-				}
+										>
+											{result.title}
+										</Item>
+									))}
+								</ItemGroup>
+							</div>
+						) : !searchResults.length && isSearchCompleted ? (
+							<div className="simple-podcasting__podcasting-search-results">
+								<ItemGroup isSeparated>
+									<Item>
+										{__(
+											'No results found.',
+											'simple-podcasting'
+										)}
+									</Item>
+								</ItemGroup>
+							</div>
+						) : null}
+					</div>
+				) : null}
 			</div>
 		</>
-	)
+	);
 }
 
 export default Edit;

--- a/assets/js/blocks/podcast-platforms/index.js
+++ b/assets/js/blocks/podcast-platforms/index.js
@@ -10,33 +10,33 @@ import './index.scss';
 /**
  * Register Podcast Platforms block
  */
-export default registerBlockType(
-	'podcasting/podcast-platforms',
-	{
-		title: __( 'Podcast Platforms', 'simple-podcasting' ),
-		description: __( 'Displays the list of platforms where the selected show is available.', 'simple-podcasting' ),
-		category: 'common',
-		icon: 'microphone',
-		supports: {
-			multiple: false,
-		},
-		attributes: {
-			showId: {
-				type: 'number',
-				default: 0,
-			},
-			iconSize: {
-				type: 'number',
-				default: 48,
-			},
-			align: {
-				type: 'string',
-				default: 'center',
-			}
-		},
-
-		edit: Edit,
-
-		save: () => null,
+export default registerBlockType('podcasting/podcast-platforms', {
+	title: __('Podcast Platforms', 'simple-podcasting'),
+	description: __(
+		'Displays the list of platforms where the selected show is available.',
+		'simple-podcasting'
+	),
+	category: 'common',
+	icon: 'microphone',
+	supports: {
+		multiple: false,
 	},
-);
+	attributes: {
+		showId: {
+			type: 'number',
+			default: 0,
+		},
+		iconSize: {
+			type: 'number',
+			default: 48,
+		},
+		align: {
+			type: 'string',
+			default: 'center',
+		},
+	},
+
+	edit: Edit,
+
+	save: () => null,
+});

--- a/assets/js/create-podcast-show.js
+++ b/assets/js/create-podcast-show.js
@@ -1,6 +1,6 @@
-import { registerPlugin } from "@wordpress/plugins";
+import { registerPlugin } from '@wordpress/plugins';
 import { store as editPostStore } from '@wordpress/edit-post';
-import { __ } from "@wordpress/i18n";
+import { __ } from '@wordpress/i18n';
 import {
 	Button,
 	Modal,
@@ -11,11 +11,14 @@ import {
 	Flex,
 	FlexItem,
 	CheckboxControl,
-} from "@wordpress/components";
+} from '@wordpress/components';
 import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
-import { useState, useEffect } from "@wordpress/element";
-import { useSelect, dispatch } from "@wordpress/data";
-import { PluginDocumentSettingPanel, store as editorStore } from '@wordpress/editor';
+import { useState, useEffect } from '@wordpress/element';
+import { useSelect, dispatch } from '@wordpress/data';
+import {
+	PluginDocumentSettingPanel,
+	store as editorStore,
+} from '@wordpress/editor';
 import { store as coreDataStore } from '@wordpress/core-data';
 
 const DEFAULT_QUERY = {
@@ -26,19 +29,19 @@ const DEFAULT_QUERY = {
 	context: 'view',
 };
 
-const CreatePodcastShowModal = ( { isModalOpen, closeModal } ) => {
-	const [ showName, setShowName ] = useState( '' );
-	const [ artistName, setArtistName ] = useState( '' );
-	const [ showCategory, setShowCategory ] = useState( '' );
-	const [ summary, setSummary ] = useState( '' );
-	const [ coverId, setCoverId ] = useState( 0 );
-	const [ coverUrl, setCoverUrl ] = useState( '' );
-	const [ ajaxInprogress, setAjaxInProgress ] = useState( false );
-	const [ isPodcastCreated, setIsPodcastCreated ] = useState( false );
+const CreatePodcastShowModal = ({ isModalOpen, closeModal }) => {
+	const [showName, setShowName] = useState('');
+	const [artistName, setArtistName] = useState('');
+	const [showCategory, setShowCategory] = useState('');
+	const [summary, setSummary] = useState('');
+	const [coverId, setCoverId] = useState(0);
+	const [coverUrl, setCoverUrl] = useState('');
+	const [ajaxInprogress, setAjaxInProgress] = useState(false);
+	const [isPodcastCreated, setIsPodcastCreated] = useState(false);
 
 	const modalStyle = {
 		maxWidth: '645px',
-		width: '100%'
+		width: '100%',
 	};
 
 	const fieldStyle = {
@@ -46,13 +49,12 @@ const CreatePodcastShowModal = ( { isModalOpen, closeModal } ) => {
 	};
 
 	const createShow = async () => {
-		setAjaxInProgress( true );
+		setAjaxInProgress(true);
 
 		try {
-			const podcast = await wp.data.dispatch( coreDataStore ).saveEntityRecord(
-				'taxonomy',
-				'podcasting_podcasts',
-				{
+			const podcast = await wp.data
+				.dispatch(coreDataStore)
+				.saveEntityRecord('taxonomy', 'podcasting_podcasts', {
 					name: showName,
 					meta: {
 						podcasting_summary: summary,
@@ -60,269 +62,351 @@ const CreatePodcastShowModal = ( { isModalOpen, closeModal } ) => {
 						podcasting_image: coverId,
 						podcasting_image_url: coverUrl,
 						podcasting_talent_name: artistName,
-					}
-				}
-			);
+					},
+				});
 
-			if ( podcast ) {
-				setIsPodcastCreated( true );
+			if (podcast) {
+				setIsPodcastCreated(true);
 			}
-		} catch ( error ) {
-			setAjaxInProgress( false );
+		} catch (error) {
+			setAjaxInProgress(false);
 		}
 
-		setAjaxInProgress( false );
+		setAjaxInProgress(false);
 	};
 
-	if ( ! isModalOpen ) {
+	if (!isModalOpen) {
 		return false;
 	}
 
-	const categoriesOptions = Object.keys( podcastingShowPluginVars.categories ).map( key => ( { value: key, label: podcastingShowPluginVars.categories[key] } ) );
+	const categoriesOptions = Object.keys(
+		podcastingShowPluginVars.categories
+	).map((key) => ({
+		value: key,
+		label: podcastingShowPluginVars.categories[key],
+	}));
 
 	return (
 		<Modal
-			title={ isPodcastCreated ? __( 'Podcast created!', 'simple-podcasting' ) : __( 'Add New Podcast', 'simple-podcasting' ) }
-			style={ modalStyle }
-			onRequestClose={ ( event ) => {
-				const selectImageBtn = event.target.closest( '.podcasting__select-image-btn' );
+			title={
+				isPodcastCreated
+					? __('Podcast created!', 'simple-podcasting')
+					: __('Add New Podcast', 'simple-podcasting')
+			}
+			style={modalStyle}
+			onRequestClose={(event) => {
+				const selectImageBtn = event.target.closest(
+					'.podcasting__select-image-btn'
+				);
 
-				if ( selectImageBtn ) {
+				if (selectImageBtn) {
 					return;
 				}
 				closeModal();
-			} }
+			}}
 		>
-			{
-				isPodcastCreated ? (
-					<>
-						<Button
-							variant="link"
-							text={ __( 'Add another Podcast', 'simple-podcasting' ) }
-							onClick={ () => {
-								setIsPodcastCreated( false );
-								setShowName( '' );
-								setShowCategory( '' );
-								setSummary( '' );
-								setCoverId( 0 );
-								setCoverUrl( '' );
-							} }
+			{isPodcastCreated ? (
+				<>
+					<Button
+						variant="link"
+						text={__('Add another Podcast', 'simple-podcasting')}
+						onClick={() => {
+							setIsPodcastCreated(false);
+							setShowName('');
+							setShowCategory('');
+							setSummary('');
+							setCoverId(0);
+							setCoverUrl('');
+						}}
+					/>
+				</>
+			) : (
+				<>
+					<div
+						className="podcasting__modal-field-row"
+						style={fieldStyle}
+					>
+						<TextControl
+							className="podcasting__modal-name-field"
+							label={__('Podcast name*', 'simple-podcasting')}
+							help={__(
+								'This is the name that listeners will see when searching or subscribing.',
+								'simple-podcasting'
+							)}
+							value={showName}
+							onChange={(val) => setShowName(val)}
+							required
 						/>
-					</>
-				) : (
-					<>
-						<div className="podcasting__modal-field-row" style={ fieldStyle }>
-							<TextControl
-								className="podcasting__modal-name-field"
-								label={ __( 'Podcast name*', 'simple-podcasting' ) }
-								help={ __( 'This is the name that listeners will see when searching or subscribing.', 'simple-podcasting' ) }
-								value={ showName }
-								onChange={ ( val ) => setShowName( val ) }
-								required
-							/>
-						</div>
+					</div>
 
-						<div className="podcasting__modal-field-row" style={ fieldStyle }>
-							<TextControl
-								className="podcasting__modal-artist-field"
-								label={ __( 'Artist name*', 'simple-podcasting' ) }
-								help={ __( 'Who’s the artist or author of your podcast show that listeners will see?', 'simple-podcasting' ) }
-								value={ artistName }
-								onChange={ ( val ) => setArtistName( val ) }
-								required
-							/>
-						</div>
+					<div
+						className="podcasting__modal-field-row"
+						style={fieldStyle}
+					>
+						<TextControl
+							className="podcasting__modal-artist-field"
+							label={__('Artist name*', 'simple-podcasting')}
+							help={__(
+								'Who’s the artist or author of your podcast show that listeners will see?',
+								'simple-podcasting'
+							)}
+							value={artistName}
+							onChange={(val) => setArtistName(val)}
+							required
+						/>
+					</div>
 
-						<div className="podcasting__modal-field-row" style={ fieldStyle }>
-							<SelectControl
-								className="podcasting__modal-category-field"
-								label={ __( 'Category*', 'simple-podcasting' ) }
-								help={ __( 'Select the category listeners will use to discover your show when browsing  podcatchers. You can also add subcategories later.', 'simple-podcasting' ) }
-								options={ categoriesOptions }
-								value={ showCategory }
-								onChange={ ( val ) => setShowCategory( val ) }
-								required
-							/>
-						</div>
+					<div
+						className="podcasting__modal-field-row"
+						style={fieldStyle}
+					>
+						<SelectControl
+							className="podcasting__modal-category-field"
+							label={__('Category*', 'simple-podcasting')}
+							help={__(
+								'Select the category listeners will use to discover your show when browsing  podcatchers. You can also add subcategories later.',
+								'simple-podcasting'
+							)}
+							options={categoriesOptions}
+							value={showCategory}
+							onChange={(val) => setShowCategory(val)}
+							required
+						/>
+					</div>
 
-						<div className="podcasting__modal-field-row" style={ fieldStyle }>
-							<TextareaControl
-								className="podcasting__modal-summary-field"
-								label={ __( 'Summary*', 'simple-podcasting' ) }
-								help={ __( 'Briefly describe to your listeners what your show is about. (No HTML please.)', 'simple-podcasting' ) }
-								rows={ 6 }
-								value={ summary }
-								onChange={ ( val ) => setSummary( val ) }
-								required
-							/>
-						</div>
+					<div
+						className="podcasting__modal-field-row"
+						style={fieldStyle}
+					>
+						<TextareaControl
+							className="podcasting__modal-summary-field"
+							label={__('Summary*', 'simple-podcasting')}
+							help={__(
+								'Briefly describe to your listeners what your show is about. (No HTML please.)',
+								'simple-podcasting'
+							)}
+							rows={6}
+							value={summary}
+							onChange={(val) => setSummary(val)}
+							required
+						/>
+					</div>
 
-						<div className="podcasting__modal-field-row" style={ fieldStyle }>
-							<MediaUploadCheck>
-								<MediaUpload
-									onSelect={ ( media ) => {
-										setCoverId( media.id );
-										setCoverUrl( media.url );
-									} }
-									allowedTypes={ [ 'image' ] }
-									value={ coverId }
-									render={ ( { open } ) => (
-										<>
-											<BaseControl label={ __( 'Cover Image*', 'simple-podcasting' ) } />
-											<Flex justify="normal">
+					<div
+						className="podcasting__modal-field-row"
+						style={fieldStyle}
+					>
+						<MediaUploadCheck>
+							<MediaUpload
+								onSelect={(media) => {
+									setCoverId(media.id);
+									setCoverUrl(media.url);
+								}}
+								allowedTypes={['image']}
+								value={coverId}
+								render={({ open }) => (
+									<>
+										<BaseControl
+											label={__(
+												'Cover Image*',
+												'simple-podcasting'
+											)}
+										/>
+										<Flex justify="normal">
+											<FlexItem>
+												<Button
+													className="podcasting__select-image-btn"
+													variant="secondary"
+													text={
+														coverId
+															? __(
+																	'Replace Image',
+																	'simple-podcasting'
+																)
+															: __(
+																	'Select Image',
+																	'simple-podcasting'
+																)
+													}
+													onClick={open}
+												/>
+											</FlexItem>
+											{coverId ? (
 												<FlexItem>
 													<Button
-														className="podcasting__select-image-btn"
+														className="podcasting__remove-image-btn"
 														variant="secondary"
-														text={ coverId ? __( 'Replace Image', 'simple-podcasting' ) : __( 'Select Image', 'simple-podcasting' ) }
-														onClick={ open }
+														text={__(
+															'Remove',
+															'simple-podcasting'
+														)}
+														isDestructive
+														onClick={() => {
+															setCoverId(0);
+															setCoverUrl('');
+														}}
 													/>
 												</FlexItem>
-												{
-													coverId ? (
-														<FlexItem>
-															<Button
-																className="podcasting__remove-image-btn"
-																variant="secondary"
-																text={ __( 'Remove', 'simple-podcasting' ) }
-																isDestructive
-																onClick={ () => {
-																	setCoverId( 0 );
-																	setCoverUrl( '' );
-																} }
-															/>
-														</FlexItem>
-													) : null
-												}
-											</Flex>
-											{
-												coverId ? (
-													<div className="podcasting-cover-preview" style={ {
-														maxWidth: '256px',
-														marginTop: '1rem',
-													} }>
-														<img src={ coverUrl } style={ { width: '100%' } } />
-													</div>
-												) : null
-											}
-											<BaseControl help={ __( 'Square images are required to properly display within podcatcher apps.Minimum size: 1400 px x 1400 px. Maximum size: 2048 px x 2048 px.', 'simple-podcasting' ) } />
-										</>
-									) }
-								/>
-							</MediaUploadCheck>
-						</div>
+											) : null}
+										</Flex>
+										{coverId ? (
+											<div
+												className="podcasting-cover-preview"
+												style={{
+													maxWidth: '256px',
+													marginTop: '1rem',
+												}}
+											>
+												<img
+													src={coverUrl}
+													style={{ width: '100%' }}
+												/>
+											</div>
+										) : null}
+										<BaseControl
+											help={__(
+												'Square images are required to properly display within podcatcher apps.Minimum size: 1400 px x 1400 px. Maximum size: 2048 px x 2048 px.',
+												'simple-podcasting'
+											)}
+										/>
+									</>
+								)}
+							/>
+						</MediaUploadCheck>
+					</div>
 
-						<Flex justify="normal" gap={ 9 }>
-							<FlexItem>
-								<Button
-									className="podcasting__create-podcast-btn"
-									variant="primary"
-									text={ __( 'Create Podcast', 'simple-podcasting' ) }
-									disabled={ ! showName || '' === showCategory || ! artistName || ! summary || ! coverId }
-									onClick={ createShow }
-									isBusy={ ajaxInprogress }
-								/>
-							</FlexItem>
-							<FlexItem>
-								<Button
-									variant="link"
-									text={ __( 'Cancel', 'simple-podcasting' ) }
-									onClick={ closeModal }
-								/>
-							</FlexItem>
-						</Flex>
-					</>
-				)
-			}
+					<Flex justify="normal" gap={9}>
+						<FlexItem>
+							<Button
+								className="podcasting__create-podcast-btn"
+								variant="primary"
+								text={__('Create Podcast', 'simple-podcasting')}
+								disabled={
+									!showName ||
+									'' === showCategory ||
+									!artistName ||
+									!summary ||
+									!coverId
+								}
+								onClick={createShow}
+								isBusy={ajaxInprogress}
+							/>
+						</FlexItem>
+						<FlexItem>
+							<Button
+								variant="link"
+								text={__('Cancel', 'simple-podcasting')}
+								onClick={closeModal}
+							/>
+						</FlexItem>
+					</Flex>
+				</>
+			)}
 		</Modal>
 	);
 };
 
 const CreatePodcastShowPlugin = () => {
-	const { allPodcasts, attachedPodcasts, currentPostId } = useSelect( ( select ) => {
-		const { getEntityRecords } = select( coreDataStore );
-		const { getCurrentPostId } = select( editorStore );
+	const { allPodcasts, attachedPodcasts, currentPostId } = useSelect(
+		(select) => {
+			const { getEntityRecords } = select(coreDataStore);
+			const { getCurrentPostId } = select(editorStore);
 
-		return {
-			allPodcasts: getEntityRecords( 'taxonomy', 'podcasting_podcasts', DEFAULT_QUERY ) || [],
-			attachedPodcasts: getEntityRecords( 'taxonomy', 'podcasting_podcasts', { post: getCurrentPostId() } ) || [],
-			currentPostId: getCurrentPostId(),
+			return {
+				allPodcasts:
+					getEntityRecords(
+						'taxonomy',
+						'podcasting_podcasts',
+						DEFAULT_QUERY
+					) || [],
+				attachedPodcasts:
+					getEntityRecords('taxonomy', 'podcasting_podcasts', {
+						post: getCurrentPostId(),
+					}) || [],
+				currentPostId: getCurrentPostId(),
+			};
 		}
-	} );
+	);
 
 	// Remove the default 'Podcast' taxonomy panel.
-	useEffect( () => {
-		dispatch( editPostStore ).removeEditorPanel( 'taxonomy-panel-podcasting_podcasts' );
-	}, [] );
+	useEffect(() => {
+		dispatch(editPostStore).removeEditorPanel(
+			'taxonomy-panel-podcasting_podcasts'
+		);
+	}, []);
 
-	const [ isModalOpen, setIsModalOpen ] = useState( false );
-	const openModal = () => setIsModalOpen( true );
-	const closeModal = () => setIsModalOpen( false );
-	const attachedPodcastIds = useSelect( ( select ) => {
-		return select( 'core/editor' ).getEditedPostAttribute( 'podcasting_podcasts' );
-	} );
+	const [isModalOpen, setIsModalOpen] = useState(false);
+	const openModal = () => setIsModalOpen(true);
+	const closeModal = () => setIsModalOpen(false);
+	const attachedPodcastIds = useSelect((select) => {
+		return select('core/editor').getEditedPostAttribute(
+			'podcasting_podcasts'
+		);
+	});
 
 	/**
 	 * Attaches the podcast term to the current post if selected.
 	 *
-	 * @param {Boolean} isChecked If the podcast term checkbox is checked.
+	 * @param {boolean} isChecked If the podcast term checkbox is checked.
 	 * @param {Integer} podcastId The podcast term ID.
 	 */
-	function attachPodcastToPost( isChecked, podcastId ) {
-		let updatedAttachedPodcastIds = [ ...attachedPodcastIds, podcastId ];
+	function attachPodcastToPost(isChecked, podcastId) {
+		let updatedAttachedPodcastIds = [...attachedPodcastIds, podcastId];
 
-		if ( isChecked ) {
-			updatedAttachedPodcastIds = [ ...attachedPodcastIds, podcastId ];
+		if (isChecked) {
+			updatedAttachedPodcastIds = [...attachedPodcastIds, podcastId];
 		} else {
-			updatedAttachedPodcastIds = attachedPodcastIds.filter( ( currentPodcastId ) => currentPodcastId !== podcastId );
+			updatedAttachedPodcastIds = attachedPodcastIds.filter(
+				(currentPodcastId) => currentPodcastId !== podcastId
+			);
 		}
 
-		dispatch( coreDataStore ).editEntityRecord(
+		dispatch(coreDataStore).editEntityRecord(
 			'postType',
 			'post',
 			currentPostId,
 			{
 				podcasting_podcasts: updatedAttachedPodcastIds,
 			}
-		)
+		);
 	}
 
 	return (
 		<>
 			<PluginDocumentSettingPanel
-				title={ __( 'Podcasts', 'simple-podcasting' ) }
-				className='podcasting__podcast-list'
+				title={__('Podcasts', 'simple-podcasting')}
+				className="podcasting__podcast-list"
 			>
-				{
-					allPodcasts.map( ( item, index ) => {
-						return (
-							<CheckboxControl
-								className="podcasting__podcast-list-item"
-								key={ index }
-								label={ item.name }
-								onChange={ ( isChecked ) => attachPodcastToPost( isChecked, item.id ) }
-								checked={ attachedPodcastIds.includes( item.id ) }
-							/>
-						)
-					} )
-				}
+				{allPodcasts.map((item, index) => {
+					return (
+						<CheckboxControl
+							className="podcasting__podcast-list-item"
+							key={index}
+							label={item.name}
+							onChange={(isChecked) =>
+								attachPodcastToPost(isChecked, item.id)
+							}
+							checked={attachedPodcastIds.includes(item.id)}
+						/>
+					);
+				})}
 				<Button
 					variant="link"
-					text={ __( 'Add New Podcast', 'simple-podcasting' ) }
-					onClick={ openModal }
-					style={ { marginTop: '12px' } }
+					text={__('Add New Podcast', 'simple-podcasting')}
+					onClick={openModal}
+					style={{ marginTop: '12px' }}
 					className="podcasting__add-new-podcast"
 				/>
 			</PluginDocumentSettingPanel>
 			<CreatePodcastShowModal
-				isModalOpen={ isModalOpen }
-				openModal={ openModal }
-				closeModal={ closeModal }
+				isModalOpen={isModalOpen}
+				openModal={openModal}
+				closeModal={closeModal}
 			/>
 		</>
-	)
+	);
 };
 
-registerPlugin( 'podcasting-create-podcast-show', {
-	render: CreatePodcastShowPlugin
-} );
+registerPlugin('podcasting-create-podcast-show', {
+	render: CreatePodcastShowPlugin,
+});

--- a/assets/js/deprecated.js
+++ b/assets/js/deprecated.js
@@ -66,22 +66,20 @@ export default [
 				type: 'string',
 				source: 'meta',
 				meta: 'podcast_episode_type',
-			}
+			},
 		},
 		supports: {
 			multiple: false,
 		},
-		save: props => {
-			const {
-				id,
-				src,
-				caption
-			} = props.attributes;
+		save: (props) => {
+			const { id, src, caption } = props.attributes;
 
 			return (
-				<figure className={ id ? `podcast-${ id }` : null }>
-					<audio controls="controls" src={ src } />
-					{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
+				<figure className={id ? `podcast-${id}` : null}>
+					<audio controls="controls" src={src} />
+					{caption && caption.length > 0 && (
+						<figcaption>{caption}</figcaption>
+					)}
 				</figure>
 			);
 		},

--- a/assets/js/edit.js
+++ b/assets/js/edit.js
@@ -28,27 +28,39 @@ import { dispatch, useSelect, useDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
 function useFeaturedImage() {
-    const featuredImageId = useSelect((select) => select('core/editor').getEditedPostAttribute('featured_media'), []);
-    const { editPost } = useDispatch('core/editor');
+	const featuredImageId = useSelect(
+		(select) =>
+			select('core/editor').getEditedPostAttribute('featured_media'),
+		[]
+	);
+	const { editPost } = useDispatch('core/editor');
 
-    const featuredImageUrl = useSelect((select) => {
-        const { getMedia } = select('core');
-        const image = getMedia(featuredImageId);
-        return image?.source_url;
-    }, [featuredImageId]);
+	const featuredImageUrl = useSelect(
+		(select) => {
+			const { getMedia } = select('core');
+			const image = getMedia(featuredImageId);
+			return image?.source_url;
+		},
+		[featuredImageId]
+	);
 
-    const setFeaturedImage = (imageId) => {
-        editPost({ featured_media: imageId });
-    };
+	const setFeaturedImage = (imageId) => {
+		editPost({ featured_media: imageId });
+	};
 
 	const removeFeaturedImage = () => {
 		editPost({ featured_media: 0 });
 	};
 
-    return { featuredImageUrl, setFeaturedImage, removeFeaturedImage, featuredImageId };
+	return {
+		featuredImageUrl,
+		setFeaturedImage,
+		removeFeaturedImage,
+		featuredImageId,
+	};
 }
 
-function Edit( props ) {
+function Edit(props) {
 	const {
 		className,
 		setAttributes,
@@ -57,7 +69,7 @@ function Edit( props ) {
 		featuredImageUrl,
 		setFeaturedImage,
 		removeFeaturedImage,
-		featuredImageId
+		featuredImageId,
 	} = props;
 
 	const {
@@ -80,9 +92,11 @@ function Edit( props ) {
 	const episodeNumber = attributes.episodeNumber || '';
 	const episodeType = attributes.episodeType || '';
 
-	const [ src, setSrc ] = useState( props.attributes.src );
+	const [src, setSrc] = useState(props.attributes.src);
 
-	const postTitle = useSelect( ( select ) => select( 'core/editor' ).getEditedPostAttribute( 'title' ) );
+	const postTitle = useSelect((select) =>
+		select('core/editor').getEditedPostAttribute('title')
+	);
 
 	const onSelectAttachment = (attachment) => {
 		// Upload and Media Library return different attachment objects.
@@ -123,7 +137,7 @@ function Edit( props ) {
 			caption: attachment.title,
 			enclosure: attachment.url + '\n' + filesize + '\n' + mime,
 		});
-		setSrc( attachment.url );
+		setSrc(attachment.url);
 	};
 
 	const onSelectURL = (newSrc) => {
@@ -151,7 +165,7 @@ function Edit( props ) {
 					console.error(err);
 				});
 
-			setSrc( newSrc );
+			setSrc(newSrc);
 		}
 	};
 
@@ -169,24 +183,33 @@ function Edit( props ) {
 		</BlockControls>
 	);
 
-	const showId = useSelect( ( __select ) => {
-		const attachedPodcastIds = __select( 'core/editor' ).getEditedPostAttribute( 'podcasting_podcasts' );
+	const showId = useSelect((__select) => {
+		const attachedPodcastIds = __select(
+			'core/editor'
+		).getEditedPostAttribute('podcasting_podcasts');
 		return attachedPodcastIds ? attachedPodcastIds[0] : null;
-	} );
-	const show = useSelect( ( __select ) => {
-		return __select('core').getEntityRecords('taxonomy', 'podcasting_podcasts', {
-			include: [ showId ],
-		});
-	} );
+	});
+	const show = useSelect((__select) => {
+		return __select('core').getEntityRecords(
+			'taxonomy',
+			'podcasting_podcasts',
+			{
+				include: [showId],
+			}
+		);
+	});
 
 	const showName = show && show[0] ? show[0]?.name : null;
-	const showImage = show && show[0] ? show[0]?.meta?.podcasting_image_url : null;
+	const showImage =
+		show && show[0] ? show[0]?.meta?.podcasting_image_url : null;
 
 	const onUpdateImage = (image) => {
 		setFeaturedImage(image.id);
 	};
 
-	const blockRef = useRef(document.querySelector('.wp-block-podcasting-podcast-outer'));
+	const blockRef = useRef(
+		document.querySelector('.wp-block-podcasting-podcast-outer')
+	);
 
 	return (
 		<Fragment>
@@ -199,12 +222,11 @@ function Edit( props ) {
 					<PanelRow>
 						<ToggleControl
 							id="podcast-captioned-form-toggle"
-							label={__(
-								'Closed Captioned',
-								'simple-podcasting'
-							)}
+							label={__('Closed Captioned', 'simple-podcasting')}
 							checked={captioned}
-							onChange={() => setAttributes({ captioned: !captioned})}
+							onChange={() =>
+								setAttributes({ captioned: !captioned })
+							}
 						/>
 					</PanelRow>
 					<PanelRow>
@@ -214,7 +236,11 @@ function Edit( props ) {
 								'simple-podcasting'
 							)}
 							checked={displayDuration}
-							onChange={() => setAttributes({ displayDuration: !displayDuration})}
+							onChange={() =>
+								setAttributes({
+									displayDuration: !displayDuration,
+								})
+							}
 						/>
 					</PanelRow>
 					<PanelRow>
@@ -224,7 +250,11 @@ function Edit( props ) {
 								'simple-podcasting'
 							)}
 							checked={displayShowTitle}
-							onChange={() => setAttributes({ displayShowTitle: !displayShowTitle})}
+							onChange={() =>
+								setAttributes({
+									displayShowTitle: !displayShowTitle,
+								})
+							}
 						/>
 					</PanelRow>
 					<PanelRow>
@@ -234,17 +264,20 @@ function Edit( props ) {
 								'simple-podcasting'
 							)}
 							checked={displayEpisodeTitle}
-							onChange={() => setAttributes({ displayEpisodeTitle: !displayEpisodeTitle})}
+							onChange={() =>
+								setAttributes({
+									displayEpisodeTitle: !displayEpisodeTitle,
+								})
+							}
 						/>
 					</PanelRow>
 					<PanelRow>
 						<ToggleControl
-							label={__(
-								'Display Show Art',
-								'simple-podcasting'
-							)}
+							label={__('Display Show Art', 'simple-podcasting')}
 							checked={displayArt}
-							onChange={() => setAttributes({ displayArt: !displayArt})}
+							onChange={() =>
+								setAttributes({ displayArt: !displayArt })
+							}
 						/>
 					</PanelRow>
 					<PanelRow>
@@ -254,7 +287,11 @@ function Edit( props ) {
 								'simple-podcasting'
 							)}
 							checked={displayExplicitBadge}
-							onChange={() => setAttributes({ displayExplicitBadge: !displayExplicitBadge})}
+							onChange={() =>
+								setAttributes({
+									displayExplicitBadge: !displayExplicitBadge,
+								})
+							}
 						/>
 					</PanelRow>
 					<PanelRow>
@@ -264,7 +301,11 @@ function Edit( props ) {
 								'simple-podcasting'
 							)}
 							checked={displaySeasonNumber}
-							onChange={() => setAttributes({ displaySeasonNumber: !displaySeasonNumber})}
+							onChange={() =>
+								setAttributes({
+									displaySeasonNumber: !displaySeasonNumber,
+								})
+							}
 						/>
 					</PanelRow>
 					<PanelRow>
@@ -274,10 +315,17 @@ function Edit( props ) {
 								'simple-podcasting'
 							)}
 							checked={displayEpisodeNumber}
-							onChange={() => setAttributes({ displayEpisodeNumber: !displayEpisodeNumber})}
+							onChange={() =>
+								setAttributes({
+									displayEpisodeNumber: !displayEpisodeNumber,
+								})
+							}
 							help={
-								! displayEpisodeTitle
-								&& __( 'The "Display Episode Title" setting should be enabled for this to display the episode number.', 'simple-podcasting' )
+								!displayEpisodeTitle &&
+								__(
+									'The "Display Episode Title" setting should be enabled for this to display the episode number.',
+									'simple-podcasting'
+								)
 							}
 						/>
 					</PanelRow>
@@ -288,13 +336,20 @@ function Edit( props ) {
 								'simple-podcasting'
 							)}
 							checked={displayEpisodeType}
-							onChange={() => setAttributes({ displayEpisodeType: !displayEpisodeType })}
+							onChange={() =>
+								setAttributes({
+									displayEpisodeType: !displayEpisodeType,
+								})
+							}
 						/>
 					</PanelRow>
 					<PanelRow>
 						<RadioControl
 							label={__('Dock Player', 'simple-podcasting')}
-							help={__('This will only affect the position of the player on the frontend.', 'simple-podcasting')}
+							help={__(
+								'This will only affect the position of the player on the frontend.',
+								'simple-podcasting'
+							)}
 							selected={isDocked}
 							options={[
 								{
@@ -310,17 +365,12 @@ function Edit( props ) {
 									value: 'bottom',
 								},
 							]}
-							onChange={(isDocked) =>
-								setAttributes({ isDocked })
-							}
+							onChange={(isDocked) => setAttributes({ isDocked })}
 						/>
 					</PanelRow>
 					<PanelRow>
 						<SelectControl
-							label={__(
-								'Explicit Content',
-								'simple-podcasting'
-							)}
+							label={__('Explicit Content', 'simple-podcasting')}
 							value={explicit}
 							options={[
 								{
@@ -336,21 +386,14 @@ function Edit( props ) {
 									label: __('Clean', 'simple-podcasting'),
 								},
 							]}
-							onChange={(explicit) =>
-								setAttributes({ explicit })
-							}
+							onChange={(explicit) => setAttributes({ explicit })}
 						/>
 					</PanelRow>
 					<PanelRow>
 						<TextControl
-							label={__(
-								'Length (MM:SS)',
-								'simple-podcasting'
-							)}
+							label={__('Length (MM:SS)', 'simple-podcasting')}
 							value={duration}
-							onChange={(duration) =>
-								setAttributes({ duration })
-							}
+							onChange={(duration) => setAttributes({ duration })}
 						/>
 					</PanelRow>
 					<PanelRow>
@@ -364,10 +407,7 @@ function Edit( props ) {
 					</PanelRow>
 					<PanelRow>
 						<TextControl
-							label={__(
-								'Episode Number',
-								'simple-podcasting'
-							)}
+							label={__('Episode Number', 'simple-podcasting')}
 							value={episodeNumber}
 							onChange={(episodeNumber) =>
 								setAttributes({ episodeNumber })
@@ -388,10 +428,7 @@ function Edit( props ) {
 									value: 'full',
 								},
 								{
-									label: __(
-										'Trailer',
-										'simple-podcasting'
-									),
+									label: __('Trailer', 'simple-podcasting'),
 									value: 'trailer',
 								},
 								{
@@ -409,17 +446,22 @@ function Edit( props ) {
 							variant="secondary"
 							onClick={() =>
 								dispatch('core/block-editor').insertBlocks(
-									createBlock(
-										'podcasting/podcast-transcript'
-									)
+									createBlock('podcasting/podcast-transcript')
 								)
 							}
 						>
 							{__('Add Transcript', 'simple-podcasting')}
 						</Button>
 					</PanelRow>
-					<h3 style={{marginTop: '20px'}}>{__('Cover Image', 'simple-podcasting')}</h3>
-					<p>{__('The featured image of the current post is used as the episode cover art. Please select a featured image to set it.', 'simple-podcasting')}</p>
+					<h3 style={{ marginTop: '20px' }}>
+						{__('Cover Image', 'simple-podcasting')}
+					</h3>
+					<p>
+						{__(
+							'The featured image of the current post is used as the episode cover art. Please select a featured image to set it.',
+							'simple-podcasting'
+						)}
+					</p>
 					<PanelRow className="cover-art-container">
 						{featuredImageUrl && (
 							<img src={featuredImageUrl} alt="Cover Image" />
@@ -431,18 +473,28 @@ function Edit( props ) {
 								allowedTypes={['image']}
 								render={({ open }) => (
 									<Button isSecondary onClick={open}>
-										{featuredImageUrl ?
-										__('Replace Cover Art', 'simple-podcasting')
-										:
-										__('Select Cover Art', 'simple-podcasting')
-										}
+										{featuredImageUrl
+											? __(
+													'Replace Cover Art',
+													'simple-podcasting'
+												)
+											: __(
+													'Select Cover Art',
+													'simple-podcasting'
+												)}
 									</Button>
 								)}
 								value={featuredImageId}
 							/>
 						</MediaUploadCheck>
 						{featuredImageUrl && (
-							<Button isLink isDestructive onClick={removeFeaturedImage}>{__('Delete Cover Art', 'simple-podcasting')}</Button>
+							<Button
+								isLink
+								isDestructive
+								onClick={removeFeaturedImage}
+							>
+								{__('Delete Cover Art', 'simple-podcasting')}
+							</Button>
 						)}
 					</PanelRow>
 				</PanelBody>
@@ -455,7 +507,11 @@ function Edit( props ) {
 								<div className="wp-block-podcasting-podcast__show-art">
 									<div className="wp-block-podcasting-podcast__image">
 										<img
-											src={featuredImageUrl ? featuredImageUrl : showImage}
+											src={
+												featuredImageUrl
+													? featuredImageUrl
+													: showImage
+											}
 											alt={showName}
 										/>
 									</div>
@@ -463,14 +519,12 @@ function Edit( props ) {
 							)}
 
 							<div className="wp-block-podcasting-podcast__details">
-
 								{displayEpisodeTitle && postTitle && (
 									<h3 className="wp-block-podcasting-podcast__show-title">
-										{displayEpisodeNumber && episodeNumber && (
-											<span>
-												{episodeNumber}.
-											</span>
-										)}
+										{displayEpisodeNumber &&
+											episodeNumber && (
+												<span>{episodeNumber}.</span>
+											)}
 										{postTitle}
 									</h3>
 								)}
@@ -483,16 +537,16 @@ function Edit( props ) {
 									)}
 									{displaySeasonNumber && seasonNumber && (
 										<span className="wp-block-podcasting-podcast__season">
-											{__(
-												'Season: ',
-												'simple-podcasting'
-											)}
+											{__('Season:', 'simple-podcasting')}
 											{seasonNumber}
 										</span>
 									)}
 									{displayEpisodeNumber && episodeNumber && (
 										<span className="wp-block-podcasting-podcast__episode">
-											{__('Episode: ', 'simple-podcasting')}
+											{__(
+												'Episode:',
+												'simple-podcasting'
+											)}
 											{episodeNumber}
 										</span>
 									)}
@@ -501,23 +555,27 @@ function Edit( props ) {
 								<div className="wp-block-podcasting-podcast__show-details">
 									{displayDuration && duration && (
 										<span className="wp-block-podcasting-podcast__duration">
-											{__('Listen Time: ', 'simple-podcasting')}
+											{__(
+												'Listen Time:',
+												'simple-podcasting'
+											)}
 											{duration}
 										</span>
 									)}
-									{displayEpisodeType && (episodeType !== 'none') && (
-										<span className="wp-block-podcasting-podcast__episode-type">
-											{__(
-												'Episode type: ',
-												'simple-podcasting'
-											)}
-											{episodeType}
-										</span>
-									)}
+									{displayEpisodeType &&
+										episodeType !== 'none' && (
+											<span className="wp-block-podcasting-podcast__episode-type">
+												{__(
+													'Episode type:',
+													'simple-podcasting'
+												)}
+												{episodeType}
+											</span>
+										)}
 									{displayExplicitBadge && (
 										<span className="wp-block-podcasting-podcast__explicit-badge">
 											{__(
-												'Explicit: ',
+												'Explicit:',
 												'simple-podcasting'
 											)}
 											{explicit}
@@ -551,10 +609,7 @@ function Edit( props ) {
 						icon="microphone"
 						labels={{
 							title: __('Podcast', 'simple-podcasting'),
-							name: __(
-								'a podcast episode',
-								'simple-podcasting'
-							),
+							name: __('a podcast episode', 'simple-podcasting'),
 						}}
 						className={className}
 						onSelect={onSelectAttachment}
@@ -570,9 +625,9 @@ function Edit( props ) {
 }
 
 function PodcastBlockWithHooks(props) {
-    const featuredImageProp = useFeaturedImage();
+	const featuredImageProp = useFeaturedImage();
 
-    return <Edit {...props} {...featuredImageProp} />;
+	return <Edit {...props} {...featuredImageProp} />;
 }
 
 export default PodcastBlockWithHooks;

--- a/assets/js/onboarding.js
+++ b/assets/js/onboarding.js
@@ -1,26 +1,32 @@
 import '../css/podcasting-onboarding.scss';
 
-( function( $ ) {
-	$( function() {
-		const selectImageBtn = $( '#simple-podcasting__upload-cover-image' );
-		const coverImage = $( 'input[name="podcast-cover-image-id"]' );
-		const coverImagePreview = $( '#simple-podcasting__cover-image-preview' );
+(function ($) {
+	$(function () {
+		const selectImageBtn = $('#simple-podcasting__upload-cover-image');
+		const coverImage = $('input[name="podcast-cover-image-id"]');
+		const coverImagePreview = $('#simple-podcasting__cover-image-preview');
 		let uploader_frame = null;
 
 		/** Upload image button handler */
-		selectImageBtn.on( 'click', function() {
-			uploader_frame = wp.media( {
-				multiple: false,
-				library: {
-					type: 'image'
-				}
-			} ).on( 'select', function() {
-				const { id, url } = uploader_frame.state().get( 'selection' ).first().toJSON();
-				coverImagePreview.html( `<img src="${ url }" />` )
-				coverImage.val( id );
-			} );
+		selectImageBtn.on('click', function () {
+			uploader_frame = wp
+				.media({
+					multiple: false,
+					library: {
+						type: 'image',
+					},
+				})
+				.on('select', function () {
+					const { id, url } = uploader_frame
+						.state()
+						.get('selection')
+						.first()
+						.toJSON();
+					coverImagePreview.html(`<img src="${url}" />`);
+					coverImage.val(id);
+				});
 
 			uploader_frame.open();
-		} );
-	} )
-} )( jQuery )
+		});
+	});
+})(jQuery);

--- a/assets/js/podcasting-edit-post.js
+++ b/assets/js/podcasting-edit-post.js
@@ -1,37 +1,37 @@
 /*global jQuery */
-jQuery( document ).ready( function( $ ) {
-	$( '#podcasting-enclosure-button' ).click( function( e ) {
+jQuery(document).ready(function ($) {
+	$('#podcasting-enclosure-button').click(function (e) {
 		e.preventDefault();
 
-		var $this = $( this ),
-			$input = $( 'input#podcasting-enclosure-url' ),
+		let $this = $(this),
+			$input = $('input#podcasting-enclosure-url'),
 			mediaUploader;
 
 		// If the uploader object has already been created, reopen the dialog.
-		if ( mediaUploader ) {
+		if (mediaUploader) {
 			mediaUploader.open();
 			return;
 		}
 
 		// eslint-disable-next-line camelcase
-		mediaUploader = wp.media.frames.file_frame = wp.media( {
-			title: $this.data( 'modalTitle' ),
+		mediaUploader = wp.media.frames.file_frame = wp.media({
+			title: $this.data('modalTitle'),
 			button: {
-				text: $this.data( 'modalButton' )
+				text: $this.data('modalButton'),
 			},
 			library: {
-				type: 'audio'
+				type: 'audio',
 			},
-			multiple: false
+			multiple: false,
 		});
 
-		mediaUploader.off( 'select' );
-		mediaUploader.on( 'select', function() {
-			var attachment = mediaUploader.state().get('selection').first();
+		mediaUploader.off('select');
+		mediaUploader.on('select', function () {
+			const attachment = mediaUploader.state().get('selection').first();
 
-			$input.val( attachment.get('url') );
+			$input.val(attachment.get('url'));
 		});
 
 		mediaUploader.open();
-	} );
-} );
+	});
+});

--- a/assets/js/podcasting-edit-term.js
+++ b/assets/js/podcasting-edit-term.js
@@ -1,53 +1,53 @@
 /*global jQuery, validateForm*/
 import '../css/podcasting-edit-term.css';
 
-jQuery( document ).ready( function( $ ) {
-
+jQuery(document).ready(function ($) {
 	// Clear Image Field.
-	function clearImageField( el ) {
-		var $link   = $( el ),
-			$wrapper  = $link.parents( '.media-wrapper' ),
-			$button   = $wrapper.find( '.podcasting-media-button' ),
-			$hidden   = $( document.getElementById( $button.data( 'slug' ) ) ),
-			$existing = $wrapper.find( '.podasting-existing-image' ),
-			$upload   = $wrapper.find( '.podcasting-upload-image' );
+	function clearImageField(el) {
+		const $link = $(el),
+			$wrapper = $link.parents('.media-wrapper'),
+			$button = $wrapper.find('.podcasting-media-button'),
+			$hidden = $(document.getElementById($button.data('slug'))),
+			$existing = $wrapper.find('.podasting-existing-image'),
+			$upload = $wrapper.find('.podcasting-upload-image');
 
 		// Update the display.
 		$upload.removeClass('hidden');
 		$existing.addClass('hidden');
-		$hidden.val( '' );
+		$hidden.val('');
 	}
 
 	// When the term add button is clicked, reset the dropdown fields.
-	$( '#submit' ).click( function() {
+	$('#submit').click(function () {
+		const $form = $('form#addtag');
 
-		var $form = $( 'form#addtag' );
-
-		if ( ! validateForm( $form ) ) {
+		if (!validateForm($form)) {
 			return;
 		}
 
 		// Add a brief delay to allow the form to submit.
-		setTimeout( function() {
-			$( '.fm-select select' ).val( 'None' );
-			clearImageField( '.podcast-media-remove' );
-			$( '#podcasting_category_1,#podcasting_category_2,#podcasting_category_3' ).val( '' );
-			window.scrollTo(0,0);
-		}, 500 );
-	} );
+		setTimeout(function () {
+			$('.fm-select select').val('None');
+			clearImageField('.podcast-media-remove');
+			$(
+				'#podcasting_category_1,#podcasting_category_2,#podcasting_category_3'
+			).val('');
+			window.scrollTo(0, 0);
+		}, 500);
+	});
 
-	var mediaUploader;
+	let mediaUploader;
 
 	// Handle media upload buttons.
-	$( 'input.podcasting-media-button' ).on( 'click', function( e ) {
+	$('input.podcasting-media-button').on('click', function (e) {
 		e.preventDefault();
 
-		var $button   = $( e.currentTarget ),
-			$hidden   = $( document.getElementById( $button.data( 'slug' ) ) ),
-			$wrapper  = $button.parents( '.media-wrapper' ),
-			$image    = $wrapper.find( 'img' ),
-			$existing = $wrapper.find( '.podasting-existing-image' ),
-			$upload   = $wrapper.find( '.podcasting-upload-image' );
+		const $button = $(e.currentTarget),
+			$hidden = $(document.getElementById($button.data('slug'))),
+			$wrapper = $button.parents('.media-wrapper'),
+			$image = $wrapper.find('img'),
+			$existing = $wrapper.find('.podasting-existing-image'),
+			$upload = $wrapper.find('.podcasting-upload-image');
 
 		// If the uploader object has already been created, reopen the dialog.
 		if (mediaUploader) {
@@ -56,27 +56,26 @@ jQuery( document ).ready( function( $ ) {
 		}
 		// Extend the wp.media object.
 		// eslint-disable-next-line camelcase
-		mediaUploader = wp.media.frames.file_frame = wp.media( {
-			title: $button.data( 'choose' ),
+		mediaUploader = wp.media.frames.file_frame = wp.media({
+			title: $button.data('choose'),
 			button: {
-				text: $button.data( 'update' )
+				text: $button.data('update'),
 			},
-			multiple: false
+			multiple: false,
 		});
 
 		// When a file is selected, grab the URL and set it as the text field's value.
-		mediaUploader.off( 'select' );
-		mediaUploader.on( 'select', function() {
-			var attachment = mediaUploader.state().get('selection').first();
+		mediaUploader.off('select');
+		mediaUploader.on('select', function () {
+			const attachment = mediaUploader.state().get('selection').first();
 
 			// Set the hidden field value.
-			$hidden.val( attachment.get('id') );
+			$hidden.val(attachment.get('id'));
 
 			// Update the display.
 			$upload.addClass('hidden');
 			$existing.removeClass('hidden');
-			$image.attr( 'src', attachment.get('url') );
-
+			$image.attr('src', attachment.get('url'));
 		});
 
 		// Open the uploader dialog
@@ -84,29 +83,35 @@ jQuery( document ).ready( function( $ ) {
 	});
 
 	// Handle media remove buttons.
-	$( '.podcast-media-remove' ).on( 'click', function( e ) {
+	$('.podcast-media-remove').on('click', function (e) {
 		e.preventDefault();
-		clearImageField( e.currentTarget );
-	} );
+		clearImageField(e.currentTarget);
+	});
 
-	const iconThemeRadioEl = $( 'input[name="podcasting_icon_theme"]' );
-	const iconWrappers = $( '.simple_podcasting__platforms-icon' );
+	const iconThemeRadioEl = $('input[name="podcasting_icon_theme"]');
+	const iconWrappers = $('.simple_podcasting__platforms-icon');
 
-	iconThemeRadioEl.on( 'change', function() {
-		const current = $( this );
+	iconThemeRadioEl.on('change', function () {
+		const current = $(this);
 		const selected = current.val();
 
-		if ( 'white' === selected ) {
-			iconWrappers.addClass( 'simple_podcasting__platforms-icon--darken-bg' );
+		if ('white' === selected) {
+			iconWrappers.addClass(
+				'simple_podcasting__platforms-icon--darken-bg'
+			);
 		} else {
-			iconWrappers.removeClass( 'simple_podcasting__platforms-icon--darken-bg' );
+			iconWrappers.removeClass(
+				'simple_podcasting__platforms-icon--darken-bg'
+			);
 		}
 
-		iconWrappers.each( ( index, icon ) => {
-			const imgEl = $( icon ).find( 'img' );
-			const platform = imgEl.data( 'platform' );
-			imgEl.attr( 'src', `${ podcastingEditPostVars.iconUrl }/${ platform }/${ selected }-100.png` );
+		iconWrappers.each((index, icon) => {
+			const imgEl = $(icon).find('img');
+			const platform = imgEl.data('platform');
+			imgEl.attr(
+				'src',
+				`${podcastingEditPostVars.iconUrl}/${platform}/${selected}-100.png`
+			);
 		});
-	} );
-} );
-
+	});
+});

--- a/assets/js/transforms.js
+++ b/assets/js/transforms.js
@@ -11,36 +11,35 @@ const transforms = {
 	from: [
 		{
 			type: 'block',
-			blocks: [ 'core/audio' ],
-			transform: ( attributes ) => {
-				return createBlock( 'podcasting/podcast', {
+			blocks: ['core/audio'],
+			transform: (attributes) => {
+				return createBlock('podcasting/podcast', {
 					id: attributes.id,
-					src: attributes.src
-				} );
+					src: attributes.src,
+				});
 			},
 		},
 	],
 	to: [
 		{
 			type: 'block',
-			blocks: [ 'core/audio' ],
-			isMatch: ( { id } ) => {
-				if ( ! id ) {
+			blocks: ['core/audio'],
+			isMatch: ({ id }) => {
+				if (!id) {
 					return false;
 				}
-				const { getMedia } = select( 'core' );
-				const media = getMedia( id );
-				return !! media && media.mime_type.includes( 'audio' );
+				const { getMedia } = select('core');
+				const media = getMedia(id);
+				return !!media && media.mime_type.includes('audio');
 			},
-			transform: ( attributes ) => {
-				return createBlock( 'core/audio', {
+			transform: (attributes) => {
+				return createBlock('core/audio', {
 					src: attributes.src,
-					id: attributes.id
-				} );
+					id: attributes.id,
+				});
 			},
 		},
 	],
-
 };
 
 export default transforms;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@10up/cypress-wp-utils": "^0.6.0",
         "@wordpress/env": "^10.37.0",
+        "@wordpress/eslint-plugin": "^23.0.0",
         "@wordpress/plugins": "^6.2.0",
         "@wordpress/prettier-config": "^2.2.0",
         "@wordpress/scripts": "^31.2.0",
@@ -22,6 +23,8 @@
         "cypress-file-upload": "^5.0.8",
         "cypress-localstorage-commands": "^2.2.4",
         "cypress-mochawesome-reporter": "^3.6.0",
+        "eslint-import-resolver-typescript": "3.5.5",
+        "eslint-plugin-cypress": "^3.6.0",
         "husky": "^8.0.1",
         "json-schema": ">=0.4.0",
         "lint-staged": "^13.0.3",
@@ -172,6 +175,35 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@babel/eslint-parser": {
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.7.tgz",
+      "integrity": "sha512-B+BO9x86VYsQHimucBAL1fxTJKF4wyKY6ZVzee9QgzdZOUfs3BaR6AQrgoGrRI+7IFS1wUz/VyQ+SoBcSpdPbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0",
+        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
@@ -2368,21 +2400,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2391,9 +2423,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4010,16 +4042,22 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -5010,16 +5048,16 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
+      "integrity": "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
       },
       "funding": {
-        "url": "https://opencollective.com/pkgr"
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/@playwright/test": {
@@ -5740,9 +5778,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -6596,9 +6634,9 @@
       "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
       "cpu": [
         "arm"
       ],
@@ -6610,9 +6648,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
       "cpu": [
         "arm64"
       ],
@@ -6624,9 +6662,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
       "cpu": [
         "arm64"
       ],
@@ -6638,9 +6676,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
       "cpu": [
         "x64"
       ],
@@ -6652,9 +6690,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
       "cpu": [
         "x64"
       ],
@@ -6666,9 +6704,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
       "cpu": [
         "arm"
       ],
@@ -6680,9 +6718,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
       "cpu": [
         "arm"
       ],
@@ -6694,9 +6732,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
       "cpu": [
         "arm64"
       ],
@@ -6708,9 +6746,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
       "cpu": [
         "arm64"
       ],
@@ -6721,10 +6759,38 @@
         "linux"
       ]
     },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
       "cpu": [
         "ppc64"
       ],
@@ -6736,9 +6802,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
       "cpu": [
         "riscv64"
       ],
@@ -6750,9 +6816,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
       "cpu": [
         "riscv64"
       ],
@@ -6764,9 +6830,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
       "cpu": [
         "s390x"
       ],
@@ -6778,9 +6844,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
       "cpu": [
         "x64"
       ],
@@ -6792,9 +6858,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
       "cpu": [
         "x64"
       ],
@@ -6805,10 +6871,24 @@
         "linux"
       ]
     },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
       "cpu": [
         "wasm32"
       ],
@@ -6816,16 +6896,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.11"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
       "cpu": [
         "arm64"
       ],
@@ -6837,9 +6919,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
       "cpu": [
         "ia32"
       ],
@@ -6851,9 +6933,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
       "cpu": [
         "x64"
       ],
@@ -7618,6 +7700,152 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wordpress/eslint-plugin": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-23.0.0.tgz",
+      "integrity": "sha512-fdgBWc7jC0JKi8j16lt51F3Sp02n7emSU3af5UFnQ5feXyJSO3mGcVJzZDpehL3ts/Clhu3II+CYOlUeek4H8g==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/eslint-parser": "7.25.7",
+        "@typescript-eslint/eslint-plugin": "^6.4.1",
+        "@typescript-eslint/parser": "^6.4.1",
+        "@wordpress/babel-preset-default": "^8.37.0",
+        "@wordpress/prettier-config": "^4.37.0",
+        "cosmiconfig": "^7.0.0",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-import-resolver-typescript": "^4.4.4",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-jest": "^27.4.3",
+        "eslint-plugin-jsdoc": "^46.4.6",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-playwright": "^0.15.3",
+        "eslint-plugin-prettier": "^5.0.0",
+        "eslint-plugin-react": "^7.27.0",
+        "eslint-plugin-react-hooks": "^4.3.0",
+        "globals": "^13.12.0",
+        "requireindex": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7",
+        "eslint": ">=8",
+        "prettier": ">=3",
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/prettier-config": {
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.50.0.tgz",
+      "integrity": "sha512-Q48oFBORY0TiVWIebPOG0ynjUAq1Hi9gXKJ69xw2i/UwOwghLOXXFLdAQhS4bJXOw0cdV5xiBaXEQYU+82r5hA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "prettier": ">=3"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/eslint-import-resolver-typescript": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.5.tgz",
+      "integrity": "sha512-nbE5XLph6TLtGYcu/U6e6ZVXyKBhbDWK5cLGk76eJ7NdZpwf1P9EFkpt1Z01mNZNrrilsAYWKH6zUkL4reoXbw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.8",
+        "get-tsconfig": "^4.10.1",
+        "is-bun-module": "^2.0.0",
+        "stable-hash-x": "^0.2.0",
+        "tinyglobby": "^0.2.14",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^16.17.0 || >=18.6.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@wordpress/hooks": {
       "version": "3.58.0",
       "dev": true,
@@ -7959,520 +8187,6 @@
         }
       }
     },
-    "node_modules/@wordpress/scripts/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/visitor-keys": "5.62.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@typescript-eslint/types": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/visitor-keys": "5.62.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@typescript-eslint/typescript-estree/node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@typescript-eslint/typescript-estree/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@typescript-eslint/utils": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
-      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@types/json-schema": "^7.0.9",
-        "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/typescript-estree": "5.62.0",
-        "eslint-scope": "^5.1.1",
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-23.0.0.tgz",
-      "integrity": "sha512-fdgBWc7jC0JKi8j16lt51F3Sp02n7emSU3af5UFnQ5feXyJSO3mGcVJzZDpehL3ts/Clhu3II+CYOlUeek4H8g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/eslint-parser": "7.25.7",
-        "@typescript-eslint/eslint-plugin": "^6.4.1",
-        "@typescript-eslint/parser": "^6.4.1",
-        "@wordpress/babel-preset-default": "^8.37.0",
-        "@wordpress/prettier-config": "^4.37.0",
-        "cosmiconfig": "^7.0.0",
-        "eslint-config-prettier": "^8.3.0",
-        "eslint-import-resolver-typescript": "^4.4.4",
-        "eslint-plugin-import": "^2.25.2",
-        "eslint-plugin-jest": "^27.4.3",
-        "eslint-plugin-jsdoc": "^46.4.6",
-        "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-playwright": "^0.15.3",
-        "eslint-plugin-prettier": "^5.0.0",
-        "eslint-plugin-react": "^7.27.0",
-        "eslint-plugin-react-hooks": "^4.3.0",
-        "globals": "^13.12.0",
-        "requireindex": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7",
-        "eslint": ">=8",
-        "prettier": ">=3",
-        "typescript": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "prettier": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/@babel/eslint-parser": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.7.tgz",
-      "integrity": "sha512-B+BO9x86VYsQHimucBAL1fxTJKF4wyKY6ZVzee9QgzdZOUfs3BaR6AQrgoGrRI+7IFS1wUz/VyQ+SoBcSpdPbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-config-prettier": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
-      "integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "eslint-config-prettier": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-import-resolver-typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
-      "integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "debug": "^4.4.1",
-        "eslint-import-context": "^0.1.8",
-        "get-tsconfig": "^4.10.1",
-        "is-bun-module": "^2.0.0",
-        "stable-hash-x": "^0.2.0",
-        "tinyglobby": "^0.2.14",
-        "unrs-resolver": "^1.7.11"
-      },
-      "engines": {
-        "node": "^16.17.0 || >=18.6.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-import-resolver-typescript"
-      },
-      "peerDependencies": {
-        "eslint": "*",
-        "eslint-plugin-import": "*",
-        "eslint-plugin-import-x": "*"
-      },
-      "peerDependenciesMeta": {
-        "eslint-plugin-import": {
-          "optional": true
-        },
-        "eslint-plugin-import-x": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-import": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
-      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rtsao/scc": "^1.1.0",
-        "array-includes": "^3.1.9",
-        "array.prototype.findlastindex": "^1.2.6",
-        "array.prototype.flat": "^1.3.3",
-        "array.prototype.flatmap": "^1.3.3",
-        "debug": "^3.2.7",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.12.1",
-        "hasown": "^2.0.2",
-        "is-core-module": "^2.16.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.8",
-        "object.groupby": "^1.0.3",
-        "object.values": "^1.2.1",
-        "semver": "^6.3.1",
-        "string.prototype.trimend": "^1.0.9",
-        "tsconfig-paths": "^3.15.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-import/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-jest": {
-      "version": "27.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
-      "integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/utils": "^5.10.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "eslint": "^7.0.0 || ^8.0.0",
-        "jest": "*"
-      },
-      "peerDependenciesMeta": {
-        "@typescript-eslint/eslint-plugin": {
-          "optional": true
-        },
-        "jest": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-jsdoc": {
-      "version": "46.10.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.10.1.tgz",
-      "integrity": "sha512-x8wxIpv00Y50NyweDUpa+58ffgSAI5sqe+zcZh33xphD0AVh+1kqr1ombaTRb7Fhpove1zfUuujlX9DWWBP5ag==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@es-joy/jsdoccomment": "~0.41.0",
-        "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.1",
-        "debug": "^4.3.4",
-        "escape-string-regexp": "^4.0.0",
-        "esquery": "^1.5.0",
-        "is-builtin-module": "^3.2.1",
-        "semver": "^7.5.4",
-        "spdx-expression-parse": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-jsx-a11y": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
-      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "aria-query": "^5.3.2",
-        "array-includes": "^3.1.8",
-        "array.prototype.flatmap": "^1.3.2",
-        "ast-types-flow": "^0.0.8",
-        "axe-core": "^4.10.0",
-        "axobject-query": "^4.1.0",
-        "damerau-levenshtein": "^1.0.8",
-        "emoji-regex": "^9.2.2",
-        "hasown": "^2.0.2",
-        "jsx-ast-utils": "^3.3.5",
-        "language-tags": "^1.0.9",
-        "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.8",
-        "safe-regex-test": "^1.0.3",
-        "string.prototype.includes": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-playwright": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.15.3.tgz",
-      "integrity": "sha512-LQMW5y0DLK5Fnpya7JR1oAYL2/7Y9wDiYw6VZqlKqcRGSgjbVKNqxraphk7ra1U3Bb5EK444xMgUlQPbMg2M1g==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "eslint": ">=7",
-        "eslint-plugin-jest": ">=25"
-      },
-      "peerDependenciesMeta": {
-        "eslint-plugin-jest": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-prettier": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
-      "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.1",
-        "synckit": "^0.11.12"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-plugin-prettier"
-      },
-      "peerDependencies": {
-        "@types/eslint": ">=8.0.0",
-        "eslint": ">=8.0.0",
-        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
-        "prettier": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/eslint": {
-          "optional": true
-        },
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-react": {
-      "version": "7.37.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
-      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-includes": "^3.1.8",
-        "array.prototype.findlast": "^1.2.5",
-        "array.prototype.flatmap": "^1.3.3",
-        "array.prototype.tosorted": "^1.1.4",
-        "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.2.1",
-        "estraverse": "^5.3.0",
-        "hasown": "^2.0.2",
-        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.1.2",
-        "object.entries": "^1.1.9",
-        "object.fromentries": "^2.0.8",
-        "object.values": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.5",
-        "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.12",
-        "string.prototype.repeat": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
-      }
-    },
     "node_modules/@wordpress/scripts/node_modules/@wordpress/prettier-config": {
       "version": "4.37.0",
       "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.37.0.tgz",
@@ -8525,71 +8239,6 @@
         "webpack": "^5.1.0"
       }
     },
-    "node_modules/@wordpress/scripts/node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/scripts/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@wordpress/scripts/node_modules/globby": {
       "version": "12.2.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-12.2.0.tgz",
@@ -8611,13 +8260,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@wordpress/scripts/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@wordpress/scripts/node_modules/prettier": {
       "name": "wp-prettier",
       "version": "3.0.3",
@@ -8635,24 +8277,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/@wordpress/scripts/node_modules/resolve": {
-      "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/@wordpress/scripts/node_modules/slash": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
@@ -8664,27 +8288,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/spdx-expression-parse": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
-      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@wordpress/stylelint-config": {
@@ -10151,15 +9754,15 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -12411,9 +12014,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12479,6 +12082,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -12498,16 +12120,16 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
-      "integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
+      "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.1",
+        "es-abstract": "^1.24.2",
         "es-errors": "^1.3.0",
         "es-set-tostringtag": "^2.1.0",
         "function-bind": "^1.1.2",
@@ -12519,7 +12141,7 @@
         "has-symbols": "^1.1.0",
         "internal-slot": "^1.1.0",
         "iterator.prototype": "^1.1.5",
-        "safe-array-concat": "^1.1.3"
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12533,9 +12155,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12575,15 +12197,18 @@
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
         "is-callable": "^1.2.7",
-        "is-date-object": "^1.0.5",
-        "is-symbol": "^1.0.4"
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12708,6 +12333,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
+      "integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-import-context": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
@@ -12734,15 +12372,15 @@
       }
     },
     "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
-      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7",
-        "is-core-module": "^2.13.0",
-        "resolve": "^1.22.4"
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -12755,10 +12393,61 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-import-resolver-node/node_modules/resolve": {
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.5.tgz",
+      "integrity": "sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "enhanced-resolve": "^5.12.0",
+        "eslint-module-utils": "^2.7.4",
+        "get-tsconfig": "^4.5.0",
+        "globby": "^13.1.3",
+        "is-core-module": "^2.11.0",
+        "is-glob": "^4.0.3",
+        "synckit": "^0.8.5"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
+      }
+    },
     "node_modules/eslint-module-utils": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
-      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
+      "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12783,6 +12472,435 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-plugin-cypress": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-3.6.0.tgz",
+      "integrity": "sha512-7IAMcBbTVu5LpWeZRn5a9mQ30y4hKp3AfTz+6nSD/x/7YyLMoBI6X7XjDLYI6zFvuy4Q4QVGl563AGEXGW/aSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globals": "^13.20.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "27.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
+      "integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.10.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "eslint": "^7.0.0 || ^8.0.0",
+        "jest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "46.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.10.1.tgz",
+      "integrity": "sha512-x8wxIpv00Y50NyweDUpa+58ffgSAI5sqe+zcZh33xphD0AVh+1kqr1ombaTRb7Fhpove1zfUuujlX9DWWBP5ag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.41.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.5.0",
+        "is-builtin-module": "^3.2.1",
+        "semver": "^7.5.4",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-playwright": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.15.3.tgz",
+      "integrity": "sha512-LQMW5y0DLK5Fnpya7JR1oAYL2/7Y9wDiYw6VZqlKqcRGSgjbVKNqxraphk7ra1U3Bb5EK444xMgUlQPbMg2M1g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=7",
+        "eslint-plugin-jest": ">=25"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
+      "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.1",
+        "synckit": "^0.11.13"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-prettier/node_modules/@pkgr/core": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/eslint-plugin-prettier/node_modules/synckit": {
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.3.6"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
@@ -12794,6 +12912,43 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-scope": {
@@ -13838,18 +13993,21 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
-        "hasown": "^2.0.2",
-        "is-callable": "^1.2.7"
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14018,9 +14176,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15186,9 +15344,9 @@
       }
     },
     "node_modules/is-bun-module/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -15212,13 +15370,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -15276,6 +15434,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extendable": {
@@ -19468,6 +19642,25 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/node-exports-info": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
+      "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
@@ -21481,15 +21674,17 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -22613,15 +22808,15 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
@@ -23906,19 +24101,20 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -23928,16 +24124,16 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
+        "es-object-atoms": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -24691,19 +24887,20 @@
       "license": "MIT"
     },
     "node_modules/synckit": {
-      "version": "0.11.12",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
+      "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.2.9"
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
-        "url": "https://opencollective.com/synckit"
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/systeminformation": {
@@ -25091,14 +25288,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -25126,9 +25323,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -25499,18 +25696,18 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0",
-        "reflect.getprototypeof": "^1.0.6"
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
       },
       "engines": {
         "node": ">= 0.4"
@@ -25651,38 +25848,41 @@
       }
     },
     "node_modules/unrs-resolver": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "napi-postinstall": "^0.3.0"
+        "napi-postinstall": "^0.3.4"
       },
       "funding": {
         "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
-        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-        "@unrs/resolver-binding-android-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-x64": "1.11.1",
-        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
     },
     "node_modules/untildify": {
@@ -26597,14 +26797,14 @@
       "license": "ISC"
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@10up/cypress-wp-utils": "^0.6.0",
     "@wordpress/env": "^10.37.0",
+    "@wordpress/eslint-plugin": "^23.0.0",
     "@wordpress/plugins": "^6.2.0",
     "@wordpress/prettier-config": "^2.2.0",
     "@wordpress/scripts": "^31.2.0",
@@ -48,6 +49,8 @@
     "cypress-file-upload": "^5.0.8",
     "cypress-localstorage-commands": "^2.2.4",
     "cypress-mochawesome-reporter": "^3.6.0",
+    "eslint-import-resolver-typescript": "3.5.5",
+    "eslint-plugin-cypress": "^3.6.0",
     "husky": "^8.0.1",
     "json-schema": ">=0.4.0",
     "lint-staged": "^13.0.3",

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -20,11 +20,9 @@ const wpEnvLibPath = path.join(path.dirname(wpEnvPackagePath), 'lib');
 
 // Directly require the files using their resolved paths
 const { loadConfig } = require(path.join(wpEnvLibPath, 'config', 'index.js'));
-const getCacheDirectory = require(path.join(
-	wpEnvLibPath,
-	'config',
-	'get-cache-directory.js'
-));
+const getCacheDirectory = require(
+	path.join(wpEnvLibPath, 'config', 'get-cache-directory.js')
+);
 
 /**
  * @type {Cypress.PluginConfig}

--- a/tests/cypress/support/functions.js
+++ b/tests/cypress/support/functions.js
@@ -8,12 +8,12 @@ export const getFirstImage = () => {
 
 /**
  * Populates a podcast taxonomy.
- * @param {Object} args The podcast data to populate.
- * @param {string} args.typeOfShowName The type of show.
- * @param {string} args.author The author of the podcast.
- * @param {string} args.summary The summary of the podcast.
- * @param {string} args.category The category of the podcast.
- * @param {boolean} args.onboarding Whether this is onboarding or not.
+ * @param {Object}  args                The podcast data to populate.
+ * @param {string}  args.typeOfShowName The type of show.
+ * @param {string}  args.author         The author of the podcast.
+ * @param {string}  args.summary        The summary of the podcast.
+ * @param {string}  args.category       The category of the podcast.
+ * @param {boolean} args.onboarding     Whether this is onboarding or not.
  */
 export const populatePodcast = (args) => {
 	for (const [key, value] of Object.entries(args)) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,7 @@ module.exports = {
 			'assets/js/blocks/latest-episode',
 			'index.js'
 		),
-		'podcast': path.resolve(
+		podcast: path.resolve(
 			process.cwd(),
 			'assets/js/blocks/podcast',
 			'index.js'


### PR DESCRIPTION
### Description of the Change

Draft for maintainer feedback: this PR focuses only on fixing ESLint dependency resolution so `wp-scripts lint-js` can load the project configs. It does not attempt to fix the existing lint violations that are surfaced afterward.

The root `.eslintrc` extends `plugin:@wordpress/eslint-plugin/recommended`, but `@wordpress/eslint-plugin` was only available as a nested dependency of `@wordpress/scripts`. Because ESLint resolves plugins from the project config location, it could not find the WordPress ESLint plugin from the project root.

There is a similar issue for Cypress linting: `tests/cypress/.eslintrc` extends `plugin:cypress/recommended`, but `eslint-plugin-cypress` was not declared as a project dependency.

After making those plugins resolvable, ESLint also reaches the WordPress config's TypeScript import resolver setup. The newer resolver interface is not compatible with this project's current ESLint 8 / `eslint-plugin-import` stack, causing:

`Resolve error: typescript with invalid interface loaded as resolver`

This PR pins `eslint-import-resolver-typescript` to `3.5.5`, which is compatible with the current ESLint stack.

After this change, `wp-scripts lint-js` loads the configs/plugins successfully and reaches the existing lint violations, mostly CRLF/Prettier-related formatting errors, which are outside the scope of this PR.

Closes #352

### How to test the Change

Using Node 20, matching `.nvmrc`:

1. Run `npm ci`.
2. Run `npx wp-scripts lint-js`.

Expected result:

- ESLint should no longer fail with missing plugin errors for `@wordpress/eslint-plugin` or `eslint-plugin-cypress`.
- ESLint should no longer fail with `Resolve error: typescript with invalid interface loaded as resolver`.
- The command may still report existing lint violations, such as CRLF/Prettier formatting errors, which are outside the scope of this PR.

I also validated config loading with:

- `./node_modules/.bin/eslint --print-config assets/js/blocks.js`
- `./node_modules/.bin/eslint --print-config tests/cypress/support/index.js`

### Changelog Entry

> Fixed - ESLint plugin dependency resolution for WordPress and Cypress lint configs.

### Credits

Props @mariozenmedina

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.

Documentation and new tests were not added because this is a development dependency/configuration fix. Existing linting still reports pre-existing formatting issues after the dependency resolution problem is fixed.