### PR TITLE
WP Compatibility Check Against Core 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Podcasting is a method to distribute audio messages through a feed to which list
 ## Requirements
 
 * PHP 7.4+
-* [WordPress](http://wordpress.org) 6.8+
+* [WordPress](http://wordpress.org) 6.9+
 * RSS feeds must not be disabled
 
 ## Installation

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      10up, helen, adamsilverstein, jakemgold, jeffpaul, cadic
 Tags:              podcasting, podcast, apple podcasts, episode, season
 Requires PHP:      7.4
-Requires at least: 6.8
+Requires at least: 6.9
 Tested up to:      7.1
 Stable tag:        2.0.0
 License:           GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      10up, helen, adamsilverstein, jakemgold, jeffpaul, cadic
 Tags:              podcasting, podcast, apple podcasts, episode, season
 Requires PHP:      7.4
 Requires at least: 6.8
-Tested up to:      7.0
+Tested up to:      7.1
 Stable tag:        2.0.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
### Description of the Change
Tested compatibility against WP Core 7.1

Closes #372 

### How to test the Change
1. Update WP Core version to 7.1 RC1 using any methods described [here](https://wordpress.org/news/2026/08/wordpress-7-1-release-candidate-1/)
2. Navigate to plugin pages
3. There should be no PHP warnings originating from any screens and functionality

### Changelog Entry

> Developer - Bumped up Tested up to from 7.0 to 7.1

### Credits

Props @zamanq 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
