### PR TITLE
Update 10up/cypress-wp-utils to 0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "use-debounce": "^8.0.4"
       },
       "devDependencies": {
-        "@10up/cypress-wp-utils": "^0.6.0",
+        "@10up/cypress-wp-utils": "^0.7.2",
         "@wordpress/env": "^11.14.0",
         "@wordpress/scripts": "^34.2.0",
         "ansi-regex": ">=6.0.1",
@@ -28,13 +28,13 @@
       }
     },
     "node_modules/@10up/cypress-wp-utils": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.6.0.tgz",
-      "integrity": "sha512-LI4IpWm9QKT8SgSmMM3k641WhUMj0fWF2KaHrtmZLVoEeqTpeYEV0hG/9FiZddHFX4+R5KPgvb9a9AFkblCsfA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.7.2.tgz",
+      "integrity": "sha512-Wv4e/iF4kqWY/dI+lhWTNBzicIqXscGC+FLnGvPIUb5pTX/kZJzjwjyGW7QtLAweiEdlcVHxFEjXdzNY3paPCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=20.19"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     ]
   },
   "devDependencies": {
-    "@10up/cypress-wp-utils": "^0.6.0",
+    "@10up/cypress-wp-utils": "^0.7.2",
     "@wordpress/env": "^11.14.0",
     "@wordpress/scripts": "^34.2.0",
     "ansi-regex": ">=6.0.1",


### PR DESCRIPTION
### Description of the Change

Upgrade Cypress utilities to a version supporting WP 6.9 - 7.2-alpha

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #376 

### How to test the Change

1. Ensure E2E test runs pass.


### Changelog Entry
> Developer - E2E tests: update 10up/cypress-wp-utils to 0.7.2.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
